### PR TITLE
#16 feat: add Drizzle schemas and dynamic sequence creation for ID generation

### DIFF
--- a/src/db/drizzle/0002_id_generation_config.sql
+++ b/src/db/drizzle/0002_id_generation_config.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "pcgl"."generated_identifiers" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"source_hash" text NOT NULL,
+	"generated_id" varchar(255) NOT NULL,
+	"config_id" integer,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "generated_identifiers_source_hash_unique" UNIQUE("source_hash")
+);
+--> statement-breakpoint
+CREATE TABLE "pcgl"."id_generation_config" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"entity_name" varchar(255) NOT NULL,
+	"field_name" varchar(255) NOT NULL,
+	"prefix" varchar(50) NOT NULL,
+	"padding_length" integer NOT NULL,
+	"sequence_name" varchar(255) NOT NULL,
+	"sequence_start" integer NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "id_generation_config_sequence_name_unique" UNIQUE("sequence_name"),
+	CONSTRAINT "id_generation_config_entity_name_field_name_unique" UNIQUE("entity_name","field_name")
+);
+--> statement-breakpoint
+ALTER TABLE "pcgl"."generated_identifiers" ADD CONSTRAINT "generated_identifiers_config_id_id_generation_config_id_fk" FOREIGN KEY ("config_id") REFERENCES "pcgl"."id_generation_config"("id") ON DELETE no action ON UPDATE no action;

--- a/src/db/drizzle/meta/0002_snapshot.json
+++ b/src/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,372 @@
+{
+  "id": "1d7bf9c5-d5cd-4fb3-ab8d-aa703d44ae4e",
+  "prevId": "bacd9f04-16ba-4706-b5ae-cb88d62c1e06",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence_name"
+          ]
+        },
+        "id_generation_config_entity_name_field_name_unique": {
+          "name": "id_generation_config_entity_name_field_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_name",
+            "field_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "CLINICAL",
+        "RESEARCH"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "ONGOING",
+        "COMPLETED"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -1,20 +1,27 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1748873487417,
-      "tag": "0000_dac_study_table_init",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1749236350650,
-      "tag": "0001_pluralise_collab_add_dac_fk",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1748873487417,
+			"tag": "0000_dac_study_table_init",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1749236350650,
+			"tag": "0001_pluralise_collab_add_dac_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1751908412532,
+			"tag": "0002_id_generation_config",
+			"breakpoints": true
+		}
+	]
 }

--- a/src/db/schemas/idGenerationConfig.ts
+++ b/src/db/schemas/idGenerationConfig.ts
@@ -13,12 +13,9 @@ export const idGenerationConfig = pcglSchema.table(
 		paddingLength: integer('padding_length').notNull(),
 		sequenceName: varchar('sequence_name', { length: 255 }).notNull().unique(),
 		sequenceStart: integer('sequence_start').notNull(),
-		sequenceIncrement: integer('sequence_increment').notNull(),
 		createdAt: timestamp('created_at', { withTimezone: false }).defaultNow(),
 	},
-	(t) => ({
-		uniqueEntityField: unique().on(t.entityName, t.fieldName),
-	}),
+	(table) => [unique().on(table.entityName, table.fieldName)],
 );
 
 export const generatedIdentifiers = pcglSchema.table('generated_identifiers', {

--- a/src/db/schemas/idGenerationConfig.ts
+++ b/src/db/schemas/idGenerationConfig.ts
@@ -1,0 +1,41 @@
+import { relations } from 'drizzle-orm';
+import { integer, serial, text, timestamp, unique, varchar } from 'drizzle-orm/pg-core';
+
+import { pcglSchema } from './generate.js';
+
+export const idGenerationConfig = pcglSchema.table(
+	'id_generation_config',
+	{
+		id: serial('id').primaryKey(),
+		entityName: varchar('entity_name', { length: 255 }).notNull(),
+		fieldName: varchar('field_name', { length: 255 }).notNull(),
+		prefix: varchar('prefix', { length: 50 }).notNull(),
+		paddingLength: integer('padding_length').notNull(),
+		sequenceName: varchar('sequence_name', { length: 255 }).notNull().unique(),
+		sequenceStart: integer('sequence_start').notNull(),
+		sequenceIncrement: integer('sequence_increment').notNull(),
+		createdAt: timestamp('created_at', { withTimezone: false }).defaultNow(),
+	},
+	(t) => ({
+		uniqueEntityField: unique().on(t.entityName, t.fieldName),
+	}),
+);
+
+export const generatedIdentifiers = pcglSchema.table('generated_identifiers', {
+	id: serial('id').primaryKey(),
+	sourceHash: text('source_hash').notNull().unique(),
+	generatedId: varchar('generated_id', { length: 255 }).notNull(),
+	configId: integer('config_id').references(() => idGenerationConfig.id),
+	createdAt: timestamp('created_at', { withTimezone: false }).defaultNow(),
+});
+
+export const idGenerationConfigRelations = relations(idGenerationConfig, ({ many }) => ({
+	generatedIds: many(generatedIdentifiers),
+}));
+
+export const generatedIdentifiersRelations = relations(generatedIdentifiers, ({ one }) => ({
+	config: one(idGenerationConfig, {
+		fields: [generatedIdentifiers.configId],
+		references: [idGenerationConfig.id],
+	}),
+}));

--- a/src/db/schemas/idGenerationConfig.ts
+++ b/src/db/schemas/idGenerationConfig.ts
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2025 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 import { relations } from 'drizzle-orm';
 import { integer, serial, text, timestamp, unique, varchar } from 'drizzle-orm/pg-core';
 

--- a/src/db/schemas/index.ts
+++ b/src/db/schemas/index.ts
@@ -19,4 +19,5 @@
 
 export * from './dacSchema.js';
 export * from './generate.js';
+export * from './idGenerationConfig.js';
 export * from './studiesSchema.js';


### PR DESCRIPTION
#16 feat: add Drizzle schemas and dynamic sequence creation for ID generation

- Created Drizzle ORM schemas under the `pcgl` schema for:
- `id_generation_config`: to configure prefix, padding, and sequence metadata.
- `generated_identifiers`: to store generated IDs and prevent duplication using source hash.
- Enforced uniqueness constraints on `(entity_name, field_name)` and `sequence_name`.
- Implemented dynamic PostgreSQL SEQUENCE creation logic using pattern `sequence_id_${id_config}`.
- Sequences are only created if they do not exist.
- Sequence properties (start, increment) are taken from config table.
- Added migration file generation.