### PR TITLE
Dictionary download endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"license": "AGPL-3.0-or-later",
 	"type": "module",
 	"dependencies": {
-		"@overture-stack/lyric": "^0.10.0",
+		"@overture-stack/lyric": "^0.11.0",
 		"axios": "^1.10.0",
 		"bytes": "^3.1.2",
 		"cors": "^2.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@overture-stack/lyric':
-    specifier: ^0.10.0
-    version: 0.10.0(@types/pg@8.15.4)
+    specifier: ^0.11.0
+    version: 0.11.0(@types/pg@8.15.4)
   axios:
     specifier: ^1.10.0
     version: 1.10.0
@@ -746,8 +746,8 @@ packages:
       fastq: 1.19.1
     dev: true
 
-  /@overture-stack/lectern-client@2.0.0-beta.4:
-    resolution: {integrity: sha512-liWphdJFLWVZKdN+SzA+KMMeLm9/qKk2xYFhv4u+desH7HhyrxielKWnbVlIITbBCIff2xUQ453CxS4Tlx546g==}
+  /@overture-stack/lectern-client@2.0.0-beta.5:
+    resolution: {integrity: sha512-dm5QRs+52uX+XwELgSWHosN8J/G8vGqSib09hCw3m6XHZo7Cjg8cQJQN89znFJiw0lCgJSAXgxyBS3imyrbWmw==}
     dependencies:
       '@overture-stack/lectern-dictionary': 2.0.0-beta.5
       '@overture-stack/lectern-validation': 2.0.0-beta.5
@@ -775,10 +775,10 @@ packages:
       zod: 3.25.76
     dev: false
 
-  /@overture-stack/lyric-data-model@0.10.0(@types/pg@8.15.4):
-    resolution: {integrity: sha512-clTaaKIF07tRyQ+VsmmHvzK1lSSysh5LxonpQ0c0YIAlxQckRFSz0AzUqUKUjGlLcqPe8jCezmkOyVxyUKJxwQ==}
+  /@overture-stack/lyric-data-model@0.11.0(@types/pg@8.15.4):
+    resolution: {integrity: sha512-4239bobE5GHdJyLy4c4AV0OKJe0AxKsQ9XnflXlx+LmmV540+HmoHAyfVoZ/mBRv8ZV1nfaBDzSXnZUhYQhKTA==}
     dependencies:
-      '@overture-stack/lectern-client': 2.0.0-beta.4
+      '@overture-stack/lectern-client': 2.0.0-beta.5
       copyfiles: 2.4.1
       dotenv: 16.6.1
       drizzle-orm: 0.29.5(@types/pg@8.15.4)(pg@8.16.3)
@@ -809,16 +809,17 @@ packages:
       - sqlite3
     dev: false
 
-  /@overture-stack/lyric@0.10.0(@types/pg@8.15.4):
-    resolution: {integrity: sha512-RpzzvdBA4IwM0FcYzqKA8WjfNF8j8HX/KF2CT/c5GHdE1T2xThXfM6zJ8SKXTh8uf3vckP4DiWgI19A4lsPc2Q==}
+  /@overture-stack/lyric@0.11.0(@types/pg@8.15.4):
+    resolution: {integrity: sha512-k0U02m0Z6MY8uQ5YcNUEtptOGR+HZwjJQgkMW0afj9JmMVLsLly9b8mNAj4imjGVviZs9A2A2+LK43zg0d2RdQ==}
     engines: {node: '>=20.0.0'}
     dependencies:
-      '@overture-stack/lectern-client': 2.0.0-beta.4
-      '@overture-stack/lyric-data-model': 0.10.0(@types/pg@8.15.4)
+      '@overture-stack/lectern-client': 2.0.0-beta.5
+      '@overture-stack/lyric-data-model': 0.11.0(@types/pg@8.15.4)
       '@overture-stack/sqon-builder': 1.1.0
       dotenv: 16.6.1
       drizzle-orm: 0.29.5(@types/pg@8.15.4)(pg@8.16.3)
       express: 4.21.2
+      jszip: 3.10.1
       lodash-es: 4.17.21
       nanoid: 5.1.5
       pg: 8.16.3
@@ -2416,6 +2417,10 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+    dev: false
+
   /immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
     dev: false
@@ -2529,6 +2534,15 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+    dev: false
+
   /jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
@@ -2551,6 +2565,12 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+    dependencies:
+      immediate: 3.0.6
+    dev: false
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2809,6 +2829,10 @@ packages:
   /package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
     dev: true
+
+  /pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3237,6 +3261,10 @@ packages:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
     dev: false
 
   /setprototypeof@1.2.0:

--- a/src/api-docs/dictionary-api.yml
+++ b/src/api-docs/dictionary-api.yml
@@ -1,5 +1,65 @@
 # Description of Dictionary API
 
+/dictionary/category/{categoryId}:
+  get:
+    summary: Get schema JSON for a specific dictionary by ID
+    tags:
+      - Dictionary
+    parameters:
+      - name: categoryId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: The ID of the category containing the dictionary
+    responses:
+      200:
+        description: Dictionary schema JSON
+        content:
+          application/json:
+            schema:
+              type: object
+              description: The schema definition JSON
+      400:
+        $ref: '#/components/responses/BadRequest'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+
+/dictionary/category/{categoryId}/templates:
+  get:
+    summary: Download data file templates for a dictionary
+    tags:
+      - Dictionary
+    parameters:
+      - name: categoryId
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: The ID of the category containing the dictionary
+      - name: fileType
+        in: query
+        required: false
+        schema:
+          type: string
+          enum: [csv, tsv]
+        description: File type for the templates
+    responses:
+      200:
+        description: A ZIP file containing all the templates
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
+      400:
+        $ref: '#/components/responses/BadRequest'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
 /dictionary/register:
   post:
     summary: Register new dictionary


### PR DESCRIPTION
## Description 
Adds a new route in the Lyric provider to download data file templates based on data category, using the existing Lectern client. This enables submitters to retrieve pre-populated TSV/CSV templates for each submission category.

## Technical details
- Updated dependency on Lyric `0.11.0`
- Updated Swagger to describe 2 new paths and its spec:
  - GET `/dictionary/category/{categoryId}`
  - GET `/dictionary/category/{categoryId}/templates`