### PR TITLE
Return 400 Bad Request on file processing failed

### DIFF
--- a/src/controllers/submission/editData.ts
+++ b/src/controllers/submission/editData.ts
@@ -103,7 +103,8 @@ export const editData = validateRequest(editDataRequestSchema, async (req, res, 
 				submissionId = uploadResult.submissionId;
 				entityList.push(entityName);
 			} catch (error) {
-				logger.error(`Error processing file`, error);
+				logger.error(`File processing failed. Error: ${error}`);
+				throw new lyricProvider.utils.errors.BadRequest(`File processing failed`, error);
 			}
 		}
 

--- a/src/controllers/submission/submit.ts
+++ b/src/controllers/submission/submit.ts
@@ -112,7 +112,8 @@ export const submit = validateRequest(submitRequestSchema, async (req, res, next
 
 				entityData[entityName] = extractedData;
 			} catch (error) {
-				logger.error(`Error processing file`, error);
+				logger.error(`File processing failed. Error: ${error}`);
+				throw new lyricProvider.utils.errors.BadRequest(`File processing failed`, error);
 			}
 		}
 

--- a/src/submission/readFile.ts
+++ b/src/submission/readFile.ts
@@ -3,8 +3,6 @@ import { parse as csvParse } from 'csv-parse';
 import firstline from 'firstline';
 import fs from 'fs';
 
-import { logger } from '@/common/logger.js';
-
 import { getSeparatorCharacter } from './format.js';
 
 /**

--- a/src/submission/readFile.ts
+++ b/src/submission/readFile.ts
@@ -3,6 +3,8 @@ import { parse as csvParse } from 'csv-parse';
 import firstline from 'firstline';
 import fs from 'fs';
 
+import { logger } from '@/common/logger.js';
+
 import { getSeparatorCharacter } from './format.js';
 
 /**
@@ -62,7 +64,7 @@ export const parseFileToRecords = async (
 		return acc;
 	}, {});
 
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		const stream = fs.createReadStream(file.path).pipe(csvParse({ delimiter: separatorCharacter }));
 
 		stream.on('data', (record: string[]) => {
@@ -80,6 +82,9 @@ export const parseFileToRecords = async (
 
 		stream.on('end', () => {
 			resolve(returnRecords);
+		});
+		stream.on('error', (error) => {
+			reject(error.message);
 		});
 
 		stream.on('close', () => {


### PR DESCRIPTION
# Description
This PR handles errors on reading file, returning a 400 Bad Request with related message.
### Example:
<img width="570" height="195" alt="image" src="https://github.com/user-attachments/assets/b263a605-b492-4ea0-9387-70349165ff33" />

## Issue related:
- #64 