### PR TITLE
Provide Long Lived Token to logged in users

### DIFF
--- a/src/common/validation/auth-validation.ts
+++ b/src/common/validation/auth-validation.ts
@@ -72,8 +72,8 @@ export type OIDCUserInfoResponse = z.infer<typeof oidcUserInfoResponseSchema>;
 export const oidcTokenResponseSchema = z
 	.object({
 		access_token: z.string(),
-		refresh_token: z.string().optional(),
-		refresh_token_iat: z.number().optional(),
+		refresh_token: z.string(),
+		refresh_token_iat: z.number(),
 		id_token: z.string(),
 	})
 	.or(

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -24,26 +24,16 @@ import type { CILogonToken } from '@/common/types/auth.js';
 import { OIDCCodeResponse } from '@/common/validation/auth-validation.js';
 import { authConfig } from '@/config/authConfig.js';
 import { lyricProvider } from '@/core/provider.js';
-import { exchangeCodeForTokens, getOidcAuthorizeUrl } from '@/external/oidcAuthenticationClient.js';
+import { exchangeCodeForTokens, getOidcAuthorizeUrl, refreshUserSession } from '@/external/oidcAuthenticationClient.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 
 const login = async (request: Request, response: Response) => {
 	response.render('login.njk', {
 		app_title: 'Clinical Submission',
 		app_subheading: 'Login',
-		redirect_url: '/auth/redirect',
+		redirect_url: getOidcAuthorizeUrl(authConfig, authConfig.loginRedirectPath),
 		currentYear: new Date().getFullYear(),
 	});
-};
-
-const redirect = async (request: Request, response: Response) => {
-	if (!authConfig.enabled) {
-		response.status(400).json({ error: 'AUTH_DISABLED', message: 'Authentication is disabled.' });
-		return;
-	}
-
-	const redirectUrl = getOidcAuthorizeUrl(authConfig, authConfig.loginRedirectPath);
-	response.redirect(redirectUrl);
 };
 
 const logout = async (request: Request, response: Response) => {
@@ -65,12 +55,12 @@ const token = validateRequest(OIDCCodeResponse, async (request, response, next) 
 	const { code } = request.query;
 
 	try {
-		const tokenResponse = await exchangeCodeForTokens(authConfig, {
+		const initialTokenResponse = await exchangeCodeForTokens(authConfig, {
 			code,
 			redirectUrl: authConfig.loginRedirectPath,
 		});
 
-		if (!tokenResponse) {
+		if (!initialTokenResponse) {
 			throw new lyricProvider.utils.errors.InternalServerError('Unable to fetch tokens. Cannot complete login flow.');
 		}
 
@@ -79,10 +69,10 @@ const token = validateRequest(OIDCCodeResponse, async (request, response, next) 
 		 * this helps when a user hits refresh on the auth helper tool page, we can just redirect them
 		 * instead of showing a 500 error.
 		 */
-		if ('error' in tokenResponse) {
-			switch (tokenResponse.error_description) {
+		if ('error' in initialTokenResponse) {
+			switch (initialTokenResponse.error_description) {
 				case 'invalid token':
-					response.redirect(`/auth/login`);
+					response.redirect(getOidcAuthorizeUrl(authConfig, authConfig.loginRedirectPath));
 					break;
 				default:
 					throw new lyricProvider.utils.errors.InternalServerError(
@@ -92,14 +82,27 @@ const token = validateRequest(OIDCCodeResponse, async (request, response, next) 
 			return;
 		}
 
-		const tokenData: CILogonToken = jwtDecode(tokenResponse.id_token);
+		// IMPORTANT: The refresh token we get from the initial token exchange will not return userInfo from CILogon, but the
+		// refresh token returned from the refreshUserSession request will return user info. This is a CILogon behaviour that
+		// is not explained or documented, but it allows the refreshToken returned from the refresh session request to be used
+		// as a long lived access token by AuthZ. Thus, we immediately fetch `refreshUserSession` once, and return tokens from
+		// that request.
+		const refreshTokenResponse = await refreshUserSession(authConfig, {
+			refreshToken: initialTokenResponse.refresh_token,
+		});
+
+		if ('error' in refreshTokenResponse) {
+			throw new lyricProvider.utils.errors.InternalServerError('Unable to retrieve user tokens from OIDC provider.');
+		}
+
+		const tokenData: CILogonToken = jwtDecode(refreshTokenResponse.id_token);
 
 		/**
 		 * The JWT returns this time as _seconds_ from the Unix Epoch,
 		 * whereas JS expects it as milliseconds, so we have to multiply by 1000
 		 * to make it compatible for any arithmetic.
 		 */
-		const tokenTimeToLive = tokenData.exp * 1000;
+		const tokenTimeToLive = Date.now() + (refreshTokenResponse.refresh_token_iat || 0);
 		const tokenIssueTime = tokenData.iat * 1000;
 
 		response.render('token.njk', {
@@ -107,7 +110,8 @@ const token = validateRequest(OIDCCodeResponse, async (request, response, next) 
 			app_subheading: 'Authentication Helper Tool',
 			app_api_docs: '/api-docs/',
 			sub: tokenData.sub,
-			accessToken: tokenResponse.access_token,
+
+			accessToken: refreshTokenResponse.refresh_token,
 			expires: new Date(tokenTimeToLive).toLocaleString('en-CA', { dateStyle: 'short', timeStyle: 'medium' }),
 			valid_till: tokenTimeToLive,
 			idp_name: tokenData.idp_name,
@@ -124,4 +128,4 @@ const token = validateRequest(OIDCCodeResponse, async (request, response, next) 
 	}
 });
 
-export { login, logout, redirect, token };
+export default { login, logout, token };

--- a/src/external/oidcAuthenticationClient.ts
+++ b/src/external/oidcAuthenticationClient.ts
@@ -22,9 +22,9 @@ import urlJoin from 'url-join';
 
 import { logger } from '@/common/logger.js';
 import {
+	type OIDCTokenResponse,
 	oidcTokenResponseSchema,
 	oidcUserInfoResponseSchema,
-	type OIDCTokenResponse,
 } from '@/common/validation/auth-validation.js';
 import { type AuthConfig } from '@/config/authConfig.js';
 import { lyricProvider } from '@/core/provider.js';

--- a/src/external/oidcAuthenticationClient.ts
+++ b/src/external/oidcAuthenticationClient.ts
@@ -21,9 +21,15 @@ import axios from 'axios';
 import urlJoin from 'url-join';
 
 import { logger } from '@/common/logger.js';
-import { oidcTokenResponseSchema, oidcUserInfoResponseSchema } from '@/common/validation/auth-validation.js';
+import {
+	oidcTokenResponseSchema,
+	oidcUserInfoResponseSchema,
+	type OIDCTokenResponse,
+} from '@/common/validation/auth-validation.js';
 import { type AuthConfig } from '@/config/authConfig.js';
 import { lyricProvider } from '@/core/provider.js';
+
+const OIDC_SCOPE = `openid profile email org.cilogon.userinfo offline_access`;
 
 /**
  * OIDC Authorization Flow Step 1
@@ -33,7 +39,7 @@ export const getOidcAuthorizeUrl = (authConfig: AuthConfig, onSuccessRedirectUrl
 	const params = new URLSearchParams({
 		client_id: authConfig.AUTH_CLIENT_ID,
 		response_type: `code`,
-		scope: `openid profile email org.cilogon.userinfo`,
+		scope: OIDC_SCOPE,
 		redirect_uri: onSuccessRedirectUrl,
 	});
 	return urlJoin(authConfig.AUTH_PROVIDER_HOST, `/authorize?${params.toString()}`);
@@ -46,7 +52,7 @@ export const getOidcAuthorizeUrl = (authConfig: AuthConfig, onSuccessRedirectUrl
 export const exchangeCodeForTokens = async (
 	authConfig: AuthConfig,
 	{ code, redirectUrl }: { code: string; redirectUrl: string },
-) => {
+): Promise<OIDCTokenResponse> => {
 	const oauth2TokenUrl = urlJoin(authConfig.AUTH_PROVIDER_HOST, `/oauth2/token`);
 	const params = {
 		code,
@@ -78,6 +84,49 @@ export const exchangeCodeForTokens = async (
 
 		logger.error(`Unexpected error exchanging auth code for tokens.`, error);
 		throw new lyricProvider.utils.errors.InternalServerError(`Unable to retrieve user tokens from OIDC provider.`);
+	}
+};
+
+export const refreshUserSession = async (
+	authConfig: AuthConfig,
+	{ refreshToken }: { refreshToken: string },
+): Promise<OIDCTokenResponse> => {
+	const oauth2RefreshUrl = urlJoin(authConfig.AUTH_PROVIDER_HOST, `/oauth2/token`);
+	const params = {
+		refresh_token: refreshToken,
+		client_id: authConfig.AUTH_CLIENT_ID,
+		client_secret: authConfig.AUTH_CLIENT_SECRET,
+		grant_type: 'refresh_token',
+		scope: OIDC_SCOPE,
+	};
+
+	try {
+		const tokenResponse = await axios.get(oauth2RefreshUrl, { params });
+		const parsedTokenResponse = oidcTokenResponseSchema.safeParse(tokenResponse.data);
+
+		if (!parsedTokenResponse.success) {
+			logger.error(
+				`OIDC Provider returned tokens for refresh request with unexpected format`,
+				parsedTokenResponse.error.message,
+			);
+			throw new lyricProvider.utils.errors.InternalServerError(
+				`Token response from refresh request has unexpected format.`,
+			);
+		}
+		return parsedTokenResponse.data;
+	} catch (error: unknown) {
+		/**
+		 * Check if we got back a valid error response. We use this because for certain errors we can recover.
+		 */
+		if (axios.isAxiosError(error) && error.status === 400 && error.response) {
+			const parsedTokenResponse = oidcTokenResponseSchema.safeParse(error.response.data);
+			if (parsedTokenResponse.success) {
+				return parsedTokenResponse.data;
+			}
+		}
+
+		logger.error(`Unexpected error using refresh_token to retrieve user tokens.`, error);
+		throw new lyricProvider.utils.errors.InternalServerError(`Unable to refresh user session from OIDC provider.`);
 	}
 };
 

--- a/src/external/pcglAuthZClient.ts
+++ b/src/external/pcglAuthZClient.ts
@@ -17,14 +17,15 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import { UserSessionResult } from '@overture-stack/lyric';
+import { Request } from 'express';
+import urlJoin from 'url-join';
+
 import { logger } from '@/common/logger.js';
 import { PCGLUserSessionResult, UserDataResponseErrorType } from '@/common/types/auth.js';
 import { Groups, userDataResponseSchema, UserDataResponseSchemaType } from '@/common/validation/auth-validation.js';
 import { authConfig } from '@/config/authConfig.js';
 import { lyricProvider } from '@/core/provider.js';
-import { UserSessionResult } from '@overture-stack/lyric';
-import { Request } from 'express';
-import urlJoin from 'url-join';
 
 /**
  * Store the service token fetched form AuthZ. This service token is used

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -19,17 +19,16 @@
 
 import express, { json, Router, urlencoded } from 'express';
 
-import { login, logout, redirect, token } from '@/controllers/authController.js';
+import authController from '@/controllers/authController.js';
 
 export const authRouter: Router = (() => {
 	const router = express.Router();
 	router.use(json());
 	router.use(urlencoded({ extended: false }));
 
-	router.get('/login', login);
-	router.get('/redirect', redirect);
-	router.get('/logout', logout);
-	router.get('/token', token);
+	router.get('/login', authController.login);
+	router.get('/logout', authController.logout);
+	router.get('/token', authController.token);
 
 	return router;
 })();

--- a/src/service/studyService.ts
+++ b/src/service/studyService.ts
@@ -28,9 +28,9 @@ import { study } from '@/db/schemas/studiesSchema.js';
 import { PostgresTransaction } from '@/db/types.js';
 import { isPostgresError, PostgresErrors } from '@/db/utils.js';
 import {
+	convertFromRecordToStudyDTO,
 	convertToRecordFromPartialStudyDTO,
 	convertToRecordFromStudyDTO,
-	convertFromRecordToStudyDTO,
 } from '@/service/dtoConversion.js';
 
 const studyService = (db: PostgresDb) => ({

--- a/src/views/static/js/token.js
+++ b/src/views/static/js/token.js
@@ -67,10 +67,4 @@ document.addEventListener('DOMContentLoaded', function () {
 
 	const refreshTokenButton = document.getElementById('refreshTokenButton');
 	refreshTokenButton.addEventListener('click', refreshToken);
-
-	const validTillElement = document.getElementById('validTilTime');
-	const validTillTime = Number(validTillElement.innerText);
-	validTillElement.innerText = '-';
-
-	renderExpireCountdown(validTillTime, validTillElement);
 });

--- a/src/views/static/js/token.js
+++ b/src/views/static/js/token.js
@@ -35,7 +35,7 @@ const copyToken = () => {
 };
 
 const refreshToken = () => {
-	window.location.replace('/auth/redirect');
+	window.location.replace('/auth/login');
 };
 
 /**

--- a/src/views/token.njk
+++ b/src/views/token.njk
@@ -52,10 +52,6 @@
 				<div>
 					<h2 class="h2">Token Information</h2>
 					<div class="info-row">
-						<p class="info-title">Valid For</p>
-						<p class="info-desc" id="validTilTime">{{ valid_till }}</p>
-					</div>
-					<div class="info-row">
 						<p class="info-title">Logged In With</p>
 						<p class="info-desc">{{ idp_name }}</p>
 					</div>


### PR DESCRIPTION
## Description

By agreement with AuthZ developers, in order to facilitate long lived user tokens, we can provide logged in users access to their Refresh Token instead of the Access Token when they log in. AuthZ will be able to verify this token until it is expired, a duration that can be configured for each OIDC provider in CoManage.

This PR makes the token shown after login on the `/auth/token` page show the refresh token instead of the access token.

## Changes
- `/auth/token` page
  - shows refresh token and expiry of refresh token
  - removes countdown timer from page since this will be quite long
- Remove `/auth/redirect` route and handler. Buttons that previously sent the browser to redirect only to then be sent to CILogon now just send the user directly to CILogon
- Update token exchange to execute `userRefreshSession` once immediately after receiving user session. This is unusual behaviour that is done to accommodate a quirk in the CILogon implementation. By exchanging the refresh token once, the second retrieved refresh token is able to be used to retrieve user data from CILogon, thus enabling the auth checks on AuthZ with the refresh token.