### PR TITLE
HOTFIX(auth): Remove Admin Only Condition From Lyric

### DIFF
--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -20,7 +20,7 @@
 import { AppConfig, provider } from '@overture-stack/lyric';
 
 import { env } from '@/config/envConfig.js';
-import { adminMiddleware } from '@/middleware/auth.js';
+import { lyricAuthMiddleware } from '@/middleware/auth.js';
 import { onFinishCommitCallback } from '@/middleware/idManager.js';
 
 const appConfig: AppConfig = {
@@ -35,7 +35,7 @@ const appConfig: AppConfig = {
 	auth: {
 		enabled: env.AUTH_ENABLED,
 		protectedMethods: env.AUTH_PROTECT_METHODS,
-		customAuthHandler: adminMiddleware,
+		customAuthHandler: lyricAuthMiddleware,
 	},
 	idService: {
 		customAlphabet: env.ID_CUSTOM_ALPHABET,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -62,13 +62,13 @@ export const authMiddleware = () => {
 };
 
 /**
- * Auth Middleware that checks specifically for admin user.
+ * Auth Middleware that checks specifically for lyric endpoints
  * Used for lyric endpoints, and is provided as a custom configuration in the appConfig of lyricProvider
  *
  * @param req request object
  * @returns
  */
-export const adminMiddleware = async (req: Request) => {
+export const lyricAuthMiddleware = async (req: Request) => {
 	const { enabled } = authConfig;
 
 	try {
@@ -93,13 +93,6 @@ export const adminMiddleware = async (req: Request) => {
 		}
 
 		const result = await fetchUserData(token);
-
-		if (!result.user?.isAdmin) {
-			return {
-				errorCode: 403,
-				errorMessage: 'Forbidden: You must be an admin to access this resource',
-			};
-		}
 
 		return result;
 	} catch (error) {


### PR DESCRIPTION
### Description

Lyric endpoints were protected against submitters from the provided middleware in lyricProvider. 
```
"message": "Forbidden: You must be an admin to access this resource"
```

### Changes

- CHANGE from name`adminMiddleware` -> `lyricAuthMiddleware`
- UPDATE `lyricAuthMiddleware` description
- REMOVE admin user check 
