### PR TITLE
#77: Update Category endpoints to include mapped studyId

### DIFF
--- a/src/controllers/categoryController.ts
+++ b/src/controllers/categoryController.ts
@@ -17,159 +17,132 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray } from 'drizzle-orm';
 
-import { logger } from "@/common/logger.js";
-import { getOrDeleteCategoryByID } from "@/common/validation/category-validation.js";
-import { lyricProvider } from "@/core/provider.js";
-import { getDbInstance } from "@/db/index.js";
-import { study } from "@/db/schemas/studiesSchema.js";
-import { validateRequest } from "@/middleware/requestValidation.js";
+import { logger } from '@/common/logger.js';
+import { getOrDeleteCategoryByID } from '@/common/validation/category-validation.js';
+import { lyricProvider } from '@/core/provider.js';
+import { getDbInstance } from '@/db/index.js';
+import { study } from '@/db/schemas/studiesSchema.js';
+import { validateRequest } from '@/middleware/requestValidation.js';
 
-const deleteCategoryById = validateRequest(
-  getOrDeleteCategoryByID,
-  async (req, res, next) => {
-    const categoryId = req.params.categoryId;
-    const db = getDbInstance();
-    const categoryRepo = lyricProvider.repositories.category;
-    const user = req.user;
+const deleteCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, res, next) => {
+	const categoryId = req.params.categoryId;
+	const db = getDbInstance();
+	const categoryRepo = lyricProvider.repositories.category;
+	const user = req.user;
 
-    try {
-      if (!user?.isAdmin) {
-        throw new lyricProvider.utils.errors.Forbidden(
-          "You must be an admin user to use this endpoint."
-        );
-      }
+	try {
+		if (!user?.isAdmin) {
+			throw new lyricProvider.utils.errors.Forbidden('You must be an admin user to use this endpoint.');
+		}
 
-      const foundCategory = await categoryRepo.getCategoryById(
-        Number(categoryId)
-      );
-      if (!foundCategory) {
-        throw new lyricProvider.utils.errors.NotFound(
-          `No Category with ID - ${categoryId} found.`
-        );
-      }
+		const foundCategory = await categoryRepo.getCategoryById(Number(categoryId));
+		if (!foundCategory) {
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID - ${categoryId} found.`);
+		}
 
-      const categoryIdNum = Number(categoryId);
+		const categoryIdNum = Number(categoryId);
 
-      if (isNaN(categoryIdNum)) {
-        throw new lyricProvider.utils.errors.BadRequest(
-          `Invalid categoryId: ${categoryId}`
-        );
-      }
+		if (isNaN(categoryIdNum)) {
+			throw new lyricProvider.utils.errors.BadRequest(`Invalid categoryId: ${categoryId}`);
+		}
 
-      const linkedStudies = await db
-        .select()
-        .from(study)
-        .where(eq(study.category_id, categoryIdNum));
-      if (linkedStudies.length > 0) {
-        throw new lyricProvider.utils.errors.BadRequest(
-          `Cannot delete category ${categoryId} because it is linked to ${linkedStudies.length} study(ies).`
-        );
-      }
+		const linkedStudies = await db.select().from(study).where(eq(study.category_id, categoryIdNum));
+		if (linkedStudies.length > 0) {
+			throw new lyricProvider.utils.errors.BadRequest(
+				`Cannot delete category ${categoryId} because it is linked to ${linkedStudies.length} study(ies).`,
+			);
+		}
 
-      await db
-        .update(study)
-        .set({ category_id: null })
-        .where(eq(study.category_id, categoryIdNum));
+		await db.update(study).set({ category_id: null }).where(eq(study.category_id, categoryIdNum));
 
-      res.status(204).send();
-      return;
-    } catch (exception) {
-      logger.error("Error in deleteCategoryById", exception);
-      next(exception);
-    }
-  }
-);
+		res.status(204).send();
+		return;
+	} catch (exception) {
+		logger.error('Error in deleteCategoryById', exception);
+		next(exception);
+	}
+});
 
-const getCategoryById = validateRequest(
-  getOrDeleteCategoryByID,
-  async (req, res, next) => {
-    const categoryId = req.params.categoryId;
-    const db = getDbInstance();
-    const categorySrvice = lyricProvider.services.category;
+const getCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, res, next) => {
+	const categoryId = req.params.categoryId;
+	const db = getDbInstance();
+	const categorySrvice = lyricProvider.services.category;
 
-    try {
-      const foundCategory = await categorySrvice.getDetails(Number(categoryId));
-      if (!foundCategory) {
-        throw new lyricProvider.utils.errors.NotFound(
-          `No Category with ID - ${categoryId} found.`
-        );
-      }
+	try {
+		const foundCategory = await categorySrvice.getDetails(Number(categoryId));
+		if (!foundCategory) {
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID - ${categoryId} found.`);
+		}
 
-      const categoryIdNum = Number(categoryId);
+		const categoryIdNum = Number(categoryId);
 
-      if (isNaN(categoryIdNum)) {
-        throw new lyricProvider.utils.errors.BadRequest(
-          `Invalid categoryId: ${categoryId}`
-        );
-      }
+		if (isNaN(categoryIdNum)) {
+			throw new lyricProvider.utils.errors.BadRequest(`Invalid categoryId: ${categoryId}`);
+		}
 
-      const linkedStudies = await db
-        .select()
-        .from(study)
-        .where(eq(study.category_id, categoryIdNum));
+		const linkedStudies = await db.select().from(study).where(eq(study.category_id, categoryIdNum));
 
-      if (linkedStudies.length == 0) {
-        logger.info("category is misconfigured, no associated Study");
-        throw new lyricProvider.utils.errors.NotFound(
-          `category is misconfigured, no associated Study ID - ${categoryId}.`
-        );
-      }
+		if (linkedStudies.length == 0) {
+			logger.info('category is misconfigured, no associated Study');
+			throw new lyricProvider.utils.errors.NotFound(
+				`category is misconfigured, no associated Study ID - ${categoryId}.`,
+			);
+		}
 
-      const response = {
-        ...foundCategory,
-        studyId: linkedStudies[0]?.category_id,
-      };
+		const response = {
+			...foundCategory,
+			studyId: linkedStudies[0]?.category_id,
+		};
 
-      res.status(200).json(response);
-      return;
-    } catch (exception) {
-      logger.error("Error in deleteCategoryById", exception);
-      next(exception);
-    }
-  }
-);
+		res.status(200).json(response);
+		return;
+	} catch (exception) {
+		logger.error('Error in deleteCategoryById', exception);
+		next(exception);
+	}
+});
 
 const listAllCategories = validateRequest({}, async (req, res, next) => {
-  const db = getDbInstance();
-  const categoryService = lyricProvider.services.category;
+	const db = getDbInstance();
+	const categoryService = lyricProvider.services.category;
 
-  try {
-    const categories = await categoryService.listAll();
-    if (!categories || categories.length === 0) {
-      return res.status(200).json([]);
-    }
+	try {
+		const categories = await categoryService.listAll();
+		if (!categories || categories.length === 0) {
+			return res.status(200).json([]);
+		}
 
-    const categoryIds = categories.map((c) => c.id);
+		const categoryIds = categories.map((c) => c.id);
 
-    const linkedStudies = await db
-      .select({
-        studyId: study.study_id,
-        categoryId: study.category_id,
-      })
-      .from(study)
-      .where(inArray(study.category_id, categoryIds));
+		const linkedStudies = await db
+			.select({
+				studyId: study.study_id,
+				categoryId: study.category_id,
+			})
+			.from(study)
+			.where(inArray(study.category_id, categoryIds));
 
-    const studiesByCategory: Record<number, string> = {};
-    for (const s of linkedStudies) {
-      if (!s.categoryId) {
-        continue;
-      }
-      studiesByCategory[s.categoryId] = s.studyId;
-    }
+		const studiesByCategory: Record<number, string> = {};
+		for (const s of linkedStudies) {
+			if (!s.categoryId) {
+				continue;
+			}
+			studiesByCategory[s.categoryId] = s.studyId;
+		}
 
-    const response = categories.map((cat) => ({
-      ...cat,
-      studyId: studiesByCategory[cat.id],
-    }));
+		const response = categories.map((cat) => ({
+			...cat,
+			studyId: studiesByCategory[cat.id],
+		}));
 
-    res.status(200).json(response);
-    return;
-  } catch (exception) {
-    logger.error("Error in listAllCategories", exception);
-    next(exception);
-  }
+		res.status(200).json(response);
+		return;
+	} catch (exception) {
+		logger.error('Error in listAllCategories', exception);
+		next(exception);
+	}
 });
 
 export default { deleteCategoryById, getCategoryById, listAllCategories };

--- a/src/routes/categoryRouter.ts
+++ b/src/routes/categoryRouter.ts
@@ -22,10 +22,19 @@ import express, { json, Router, urlencoded } from 'express';
 import categoryController from '@/controllers/categoryController.js';
 import { authMiddleware } from '@/middleware/auth.js';
 
-export const categoryRouter: Router = (() => {
+export const adminCategoryRouter: Router = (() => {
 	const router = express.Router();
 	router.use(json());
 	router.use(urlencoded({ extended: false }));
 	router.delete('/:categoryId', authMiddleware(), categoryController.deleteCategoryById);
+	return router;
+})();
+
+export const categoryRouter: Router = (() => {
+	const router = express.Router();
+	router.use(json());
+	router.use(urlencoded({ extended: false }));
+	router.get('/:categoryId', categoryController.getCategoryById);
+	router.get('/', categoryController.listAllCategories);
 	return router;
 })();

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,7 +36,7 @@ import { authRouter } from './routes/auth.js';
 import { dacRouter } from './routes/dac.js';
 import { studyRouter } from './routes/study.js';
 import { dictionaryRouter } from './routes/dictionary.js';
-import { categoryRouter } from './routes/categoryRouter.js';
+import { adminCategoryRouter, categoryRouter } from './routes/categoryRouter.js';
 
 const app = express();
 
@@ -88,12 +88,12 @@ app.use('/auth', authRouter);
 
 // Lyric routes
 app.use('/audit', lyricProvider.routers.audit);
-app.use('/category', lyricProvider.routers.category);
+app.use('/category', categoryRouter);
 app.use('/data', lyricProvider.routers.submittedData);
 app.use('/dictionary', dictionaryRouter);
 app.use('/submission', submissionRouter);
 app.use('/validator', lyricProvider.routers.validator);
-app.use('/admin/category', categoryRouter);
+app.use('/admin/category', adminCategoryRouter);
 
 // Swagger route
 app.use('/api-docs', openAPIRouter);


### PR DESCRIPTION
### Summary

Expose the mapped studyId on Category reads and lists, and treat misconfigured Categories (no mapped Study) as not found. Also split the admin-only delete into /admin/category/:categoryId and block deletion when linked Studies exist.

### Related Issues
#77 — Study-Category Mapping 3: Update Category endpoints to return their mapped Study ID
Parent: Feature – Create mapping between category and organization

### Description of Changes

**API (Server)**

- GET /category/:categoryId

Now returns { ...category, studyId: "<Study.study_id>" }.
If no Study is linked to the Category, we log the misconfiguration and return 404 Not Found with a clear message.
Validates that categoryId is numeric; returns 400 Bad Request for invalid inputs.

- GET /category

Now returns a list of categories, each with a studyId (when present).
Categories with no linked Study are filtered out from the response (and logged as misconfigured).
Uses a single batched query to fetch Study links for all listed Categories.

- DELETE 

Admin-only (protected by authMiddleware()).
Returns 204 No Content on success.
If any Studies are linked to the Category, deletion is blocked with 400 Bad Request, including the count of linked Studies.
Validates numeric categoryId; returns 400 Bad Request for invalid inputs.
Returns 404 Not Found if the Category does not exist.

More description is yet to be added.