### PR TITLE
feat(iim): remove notNull and unique for internalId and insert default

### DIFF
--- a/src/common/validation/id-manager-validation.ts
+++ b/src/common/validation/id-manager-validation.ts
@@ -23,7 +23,7 @@ export const iimConfigObject = z.object({
 	entityName: z.string(),
 	fieldName: z.string(),
 	prefix: z.string(),
-	internalId: z.string(),
+	internalId: z.string().optional(),
 	paddingLength: z.number().int().positive().default(8),
 	parentEntityName: z.string().optional(),
 	parentFieldName: z.string().optional(),

--- a/src/db/drizzle/0004_add_internal_id_iim.sql
+++ b/src/db/drizzle/0004_add_internal_id_iim.sql
@@ -1,2 +1,1 @@
-ALTER TABLE "pcgl"."id_generation_config" ADD COLUMN "internal_id" varchar(50) NOT NULL;--> statement-breakpoint
-ALTER TABLE "pcgl"."id_generation_config" ADD CONSTRAINT "id_generation_config_internal_id_unique" UNIQUE("internal_id");
+ALTER TABLE "pcgl"."id_generation_config" ADD COLUMN "internal_id" varchar(50);

--- a/src/db/drizzle/meta/0004_snapshot.json
+++ b/src/db/drizzle/meta/0004_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9f11a078-c6d9-439e-b438-3cc6c161f6a2",
+  "id": "ca47ccbf-357c-4413-9c7a-bdd13f3bae0b",
   "prevId": "5dbfb85b-07d8-4750-b583-f53d2870a23a",
   "version": "7",
   "dialect": "postgresql",
@@ -159,7 +159,7 @@
           "name": "internal_id",
           "type": "varchar(50)",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "padding_length": {
           "name": "padding_length",
@@ -196,13 +196,6 @@
           "nullsNotDistinct": false,
           "columns": [
             "entity_name"
-          ]
-        },
-        "id_generation_config_internal_id_unique": {
-          "name": "id_generation_config_internal_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "internal_id"
           ]
         },
         "id_generation_config_sequence_name_unique": {

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "7",
-      "when": 1757952233705,
+      "when": 1758642317849,
       "tag": "0004_add_internal_id_iim",
       "breakpoints": true
     }

--- a/src/db/schemas/idGenerationConfig.ts
+++ b/src/db/schemas/idGenerationConfig.ts
@@ -26,7 +26,7 @@ export const idGenerationConfig = pcglSchema.table('id_generation_config', {
 	entityName: varchar('entity_name', { length: 255 }).notNull().unique(),
 	fieldName: varchar('field_name', { length: 255 }).notNull(),
 	prefix: varchar('prefix', { length: 50 }).notNull(),
-	internalId: varchar('internal_id', { length: 50 }).notNull().unique(),
+	internalId: varchar('internal_id', { length: 50 }),
 	paddingLength: integer('padding_length').notNull(),
 	sequenceName: varchar('sequence_name', { length: 255 }).notNull().unique(),
 	sequenceStart: integer('sequence_start').notNull(),


### PR DESCRIPTION
### Description

Development currently having migration issues due to the new col `internalId` being not nullable and unique.
Seeing as the only option would be to truncate the db to resolve the issues, it is not a feasible solution going forward.
Solution is to remove the restraints and programmatically insert a default internal id if the IIMCONFIG does not provide one

### Changes
- Removed `notNullable` and `unique` col restraints 
- Remove previous migration
- Update zod iimConfigObject internalId to be optional
- Manually generate internalId if internalId field does not exist in config object
