### PR TITLE
#97: Update swagger file description

### DIFF
--- a/src/api-docs/submission-api.yml
+++ b/src/api-docs/submission-api.yml
@@ -191,11 +191,17 @@
             properties:
               files:
                 type: array
+                description: >
+                  One or multiple files containing the data to insert.  
+                  Each file must be based on the template for the corresponding entity  
+                  (e.g., **participant.csv**).
                 items:
                   type: string
                   format: binary
               organization:
                 type: string
+                description: >
+                  Organization the Submission belongs to.
             required:
               - files
               - organization
@@ -232,11 +238,21 @@
             properties:
               files:
                 type: array
+                description: >
+                  One or multiple files containing the data to edit.  
+                  Each file must be based on the template for the corresponding entity  
+                  (e.g., **participant.csv**).  
+
+                  In addition to the template fields, each file must include an extra column named  
+                  **systemId**, which represents the unique system identifier used to match and update  
+                  existing records in the system.
                 items:
                   type: string
                   format: binary
               organization:
                 type: string
+                description: >
+                  Organization the Submission belongs to.
             required:
               - files
               - organization


### PR DESCRIPTION
# Description
This PR adds a description for `files` and `organization` fields in the **Submit** and **Edit Data** endpoints. The description clarifies how files should be prepared (using the provided templates and including a `systemId` column) and explains the meaning of the organization field

# Tickets related:
- https://github.com/Pan-Canadian-Genome-Library/Roadmap/issues/97