### PR TITLE
Fix delete submission auth condition

### DIFF
--- a/apps/submission/src/controllers/submissionController.ts
+++ b/apps/submission/src/controllers/submissionController.ts
@@ -367,7 +367,7 @@ const deleteSubmissionById = validateRequest(
 				throw new lyricProvider.utils.errors.BadRequest(`Submission '${submissionId}' not found`);
 			}
 
-			if (authEnabled && (user?.isAdmin || user?.username !== submission?.createdBy)) {
+			if (authEnabled && !user?.isAdmin && user?.username !== submission?.createdBy) {
 				throw new lyricProvider.utils.errors.Forbidden('You do not have permission to delete this resource');
 			}
 
@@ -399,7 +399,7 @@ const deleteEntityName = validateRequest(
 				throw new lyricProvider.utils.errors.BadRequest(`Submission '${submissionId}' not found`);
 			}
 
-			if (authEnabled && (user?.isAdmin || user?.username !== submission?.createdBy)) {
+			if (authEnabled && !user?.isAdmin && user?.username !== submission?.createdBy) {
 				throw new lyricProvider.utils.errors.Forbidden('You do not have permission to delete this resource');
 			}
 


### PR DESCRIPTION
# Issue Description
A `Data Admin` submitter user is not able to delete a submission (`DELETE /submission/{submission}`)


## Expected:
Users to be able to delete a submission when:
- User is an `Data Admin` OR
- User is the creator of the submission



