### PR TITLE
Change POST content to "application/json"

### DIFF
--- a/apps/submission/src/api-docs/dac-api.yml
+++ b/apps/submission/src/api-docs/dac-api.yml
@@ -57,7 +57,7 @@
       - $ref: '#/components/parameters/path/DacId'
     requestBody:
       content:
-        application/x-www-form-urlencoded:
+        application/json:
           schema:
             type: object
             properties:
@@ -102,7 +102,7 @@
       - DAC
     requestBody:
       content:
-        application/x-www-form-urlencoded:
+        application/json:
           schema:
             type: object
             properties:

--- a/apps/submission/src/api-docs/dictionary-api.yml
+++ b/apps/submission/src/api-docs/dictionary-api.yml
@@ -67,7 +67,7 @@
       - Dictionary
     requestBody:
       content:
-        application/x-www-form-urlencoded:
+        application/json:
           schema:
             type: object
             properties:
@@ -82,6 +82,7 @@
                 description: A matching Dictionary Name defined on Dictionary Manager
               dictionaryVersion:
                 type: string
+                example: '1.0'
                 description: A matching Dictionary Version defined on Dictionary Manager
               defaultCentricEntity:
                 type: string


### PR DESCRIPTION
# Description
This PR fixes the issue where Swagger automatically truncates the **dictionaryVersion** numbers. (This is know issue in Javascript formatting numbers. ref: https://github.com/swagger-api/swagger-ui/issues/7337)

### Example: 
dictionaryVersion  1.0 turns to 1.  

## Solution: 
- Changed Swagger doc to use `Content-Type: application/json` in endpoints:
  - POST `dictionary/register`
  - POST `dac/create`
  - PATCH `dac/{dacId}`

## Issues:
- https://github.com/Pan-Canadian-Genome-Library/clinical-submission/issues/110