### PR TITLE
117 - Remove the study link from a category

### DIFF
--- a/apps/submission/src/api-docs/categories-api.yml
+++ b/apps/submission/src/api-docs/categories-api.yml
@@ -46,8 +46,10 @@
         $ref: '#/components/responses/ServerError'
       503:
         $ref: '#/components/responses/ServiceUnavailableError'
+
+/category/{categoryId}/study:
   delete:
-    summary: Delete a category by ID. (🔒 Admin only)
+    summary: Remove the study link from a category (🔒 Admin only)
     tags:
       - Category
     parameters:
@@ -56,12 +58,12 @@
         required: true
         schema:
           type: string
-        description: ID of the category to delete
+        description: ID of the category whose study link will be removed
     security:
       - bearerAuth: []
     responses:
       204:
-        description: Category deleted successfully (no content)
+        description: Study link successfully removed (no content)
       400:
         $ref: '#/components/responses/BadRequest'
       401:

--- a/apps/submission/src/common/validation/category-validation.ts
+++ b/apps/submission/src/common/validation/category-validation.ts
@@ -29,7 +29,13 @@ interface CategoryIDParams extends ParamsDictionary {
 	categoryId: string;
 }
 
-export const getOrDeleteCategoryByID: RequestValidation<object, ParsedQs, CategoryIDParams> = {
+export const getCategoryByIDReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
+	pathParams: z.object({
+		categoryId: stringNotEmpty,
+	}),
+};
+
+export const removeStudyLinkFromCategoryReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
 	pathParams: z.object({
 		categoryId: stringNotEmpty,
 	}),

--- a/apps/submission/src/controllers/categoryController.ts
+++ b/apps/submission/src/controllers/categoryController.ts
@@ -18,13 +18,16 @@
  */
 
 import { logger } from '@/common/logger.js';
-import { getOrDeleteCategoryByID } from '@/common/validation/category-validation.js';
+import {
+	getCategoryByIDReqValidation,
+	removeStudyLinkFromCategoryReqValidation,
+} from '@/common/validation/category-validation.js';
 import { lyricProvider } from '@/core/provider.js';
 import { getDbInstance } from '@/db/index.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 import { studyService } from '@/service/studyService.js';
 
-const deleteCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, res, next) => {
+const unlinkStudiesFromCategory = validateRequest(removeStudyLinkFromCategoryReqValidation, async (req, res, next) => {
 	try {
 		const categoryId = Number(req.params.categoryId);
 		const database = getDbInstance();
@@ -39,7 +42,7 @@ const deleteCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, 
 		const submittedDataCount = await lyricProvider.repositories.submittedData.getTotalRecordsByCategoryId(categoryId);
 		if (submittedDataCount > 0) {
 			throw new lyricProvider.utils.errors.BadRequest(
-				`Cannot delete category ${categoryId} because it is linked to ${submittedDataCount} records in submittedData`,
+				`Cannot remove study link from category ${categoryId} because it has ${submittedDataCount} records submitted`,
 			);
 		}
 
@@ -51,12 +54,12 @@ const deleteCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, 
 		res.status(204).send();
 		return;
 	} catch (exception) {
-		logger.error(exception, 'Error in deleteCategoryById');
+		logger.error(exception, 'Error in unlinkStudiesFromCategory');
 		next(exception);
 	}
 });
 
-const getCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, res, next) => {
+const getCategoryById = validateRequest(getCategoryByIDReqValidation, async (req, res, next) => {
 	const categoryId = Number(req.params.categoryId);
 	const database = getDbInstance();
 	const categoryService = lyricProvider.services.category;
@@ -85,7 +88,7 @@ const getCategoryById = validateRequest(getOrDeleteCategoryByID, async (req, res
 		res.status(200).json(response);
 		return;
 	} catch (exception) {
-		logger.error(exception, 'Error in deleteCategoryById');
+		logger.error(exception, 'Error in getCategoryById');
 		next(exception);
 	}
 });
@@ -126,4 +129,4 @@ const listAllCategories = validateRequest({}, async (req, res, next) => {
 	}
 });
 
-export default { deleteCategoryById, getCategoryById, listAllCategories };
+export default { unlinkStudiesFromCategory, getCategoryById, listAllCategories };

--- a/apps/submission/src/routes/categoryRouter.ts
+++ b/apps/submission/src/routes/categoryRouter.ts
@@ -28,7 +28,11 @@ export const categoryRouter: Router = (() => {
 	router.use(json());
 	router.use(urlencoded({ extended: false }));
 
-	router.delete('/:categoryId', authMiddleware({ requireAdmin: true }), categoryController.deleteCategoryById);
+	router.delete(
+		'/:categoryId/study',
+		authMiddleware({ requireAdmin: true }),
+		categoryController.unlinkStudiesFromCategory,
+	);
 
 	// Public endpoints – do not require authentication
 	router.get('/', lyricProvider.controllers.category.listAll);


### PR DESCRIPTION
# Description
This PR updates the path definition of the DELETE `/category/{categoryId}` endpoint.
The endpoint’s internal logic remains unchanged — it does not delete the category itself but only removes its link to the associated study.

## Details
- Changed the path of DELETE `/category/{categoryId}` -> `/category/{categoryId}/study`
- Updated Swagger description specifying this endpoint only removes the study link of the category.

## Issue:
- https://github.com/Pan-Canadian-Genome-Library/Roadmap/issues/117