### PR TITLE
#139: Delete Submission by entity name bug

### DIFF
--- a/apps/submission/src/controllers/submissionController.ts
+++ b/apps/submission/src/controllers/submissionController.ts
@@ -395,7 +395,7 @@ const deleteEntityName = validateRequest(deleteEntityRequestSchema, async (req, 
 		const user = req.user;
 
 		const submissionId = Number(req.params.submissionId);
-		const index = Number(req.query.index);
+		const index = req.query.index ? Number(req.query.index) : null;
 		const actionType = SUBMISSION_ACTION_TYPE.parse(req.params.actionType.toUpperCase());
 		const entityName = req.query.entityName;
 		const authEnabled = authConfig.enabled;


### PR DESCRIPTION
# Description
This PR fixes an issue where not passing the request param `index` was parsed to `NaN` making the endpoint not doing anything.

## Changes:
- The request param `index` is parsed to Number only when is passed, otherwise explicitly defined as `null`.

## Issue:
- https://github.com/Pan-Canadian-Genome-Library/Roadmap/issues/139