### PR TITLE
Retrieve Summary of Submission endpoint

### DIFF
--- a/apps/submission/package.json
+++ b/apps/submission/package.json
@@ -27,7 +27,7 @@
 		"start:prod": "pnpm migrate:db:prod && pnpm migrate:pcgl:db:prod && NODE_ENV=production node --import=./register.js src/index.js"
 	},
 	"dependencies": {
-		"@overture-stack/lyric": "^0.14.0",
+		"@overture-stack/lyric": "^0.15.0",
 		"axios": "^1.10.0",
 		"bytes": "^3.1.2",
 		"cors": "^2.8.5",

--- a/apps/submission/src/api-docs/schemas.yml
+++ b/apps/submission/src/api-docs/schemas.yml
@@ -246,6 +246,40 @@ components:
           type: string
           description: Last Updated date of the DAC record
 
+    DeleteSubmissionEntityResult:
+      required:
+        - status
+        - description
+      type: object
+      properties:
+        description:
+          type: string
+          description: Description of deleting partially Submission data
+        status:
+          type: string
+          description: Result of deleting Submission data
+          enum: ['PROCESSING']
+        submissionId:
+          type: string
+          description: ID of the Submission
+
+    DeleteSubmissionResult:
+      required:
+        - status
+        - description
+      type: object
+      properties:
+        description:
+          type: string
+          description: Description of closing the Submission
+        status:
+          type: string
+          description: Result of closing the Submission
+          enum: ['CLOSED']
+        submissionId:
+          type: string
+          description: ID of the Submission
+
     GetSubmittedDataResult:
       type: object
       properties:
@@ -390,7 +424,7 @@ components:
           nullable: true
           description: Last Updated date of the Study record, will be null if never updated.
 
-    SubmissionResult:
+    SubmissionDetailsResult:
       type: object
       properties:
         id:
@@ -496,7 +530,7 @@ components:
           type: string
           description: User name who last updated the submission
 
-    SubmissionsSummaryResult:
+    ListSubmissionsResult:
       type: object
       properties:
         pagination:
@@ -513,9 +547,9 @@ components:
         records:
           type: array
           items:
-            $ref: '#/components/schemas/SubmissionSummary'
+            $ref: '#/components/schemas/SubmissionResult'
 
-    SubmissionSummary:
+    SubmissionResult:
       type: object
       properties:
         id:
@@ -571,21 +605,24 @@ components:
             inserts:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
             updates:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
             deletes:
               type: object
               additionalProperties:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ValidationError'
+                type: object
+                properties:
+                  recordsCount:
+                    type: number
         organization:
           type: string
           description: Organization the Submission belongs to

--- a/apps/submission/src/api-docs/submission-api.yml
+++ b/apps/submission/src/api-docs/submission-api.yml
@@ -2,7 +2,7 @@
 
 /submission/{submissionId}:
   get:
-    summary: Get submission by ID
+    summary: Get submission information by ID
     tags:
       - Submission
     parameters:
@@ -14,7 +14,7 @@
       - bearerAuth: []
     responses:
       200:
-        description: Submission details
+        description: Submission information
         content:
           application/json:
             schema:
@@ -32,7 +32,7 @@
         $ref: '#/components/responses/ServiceUnavailableError'
 
   delete:
-    summary: Clear an Active Submission by ID
+    summary: Close an Active Submission by ID
     tags:
       - Submission
     parameters:
@@ -44,11 +44,11 @@
       - bearerAuth: []
     responses:
       200:
-        description: Submission cleared successfully. Returns the current Active Submission
+        description: Submission closed successfully.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubmissionResult'
+              $ref: '#/components/schemas/DeleteSubmissionResult'
       400:
         $ref: '#/components/responses/BadRequest'
       401:
@@ -59,6 +59,35 @@
         $ref: '#/components/responses/NotFound'
       409:
         $ref: '#/components/responses/StatusConflict'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+/submission/{submissionId}/details:
+  get:
+    summary: Get detailed submission information
+    tags:
+      - Submission
+    parameters:
+      - name: submissionId
+        in: path
+        type: string
+        required: true
+    responses:
+      200:
+        description: Full submission payload
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmissionDetailsResult'
+
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      403:
+        $ref: '#/components/responses/ForbiddenError'
+      404:
+        $ref: '#/components/responses/NotFound'
       500:
         $ref: '#/components/responses/ServerError'
       503:
@@ -101,11 +130,11 @@
       - bearerAuth: []
     responses:
       200:
-        description: Submission cleared successfully. Returns the current Active Submission
+        description: Submission cleared successfully.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubmissionResult'
+              $ref: '#/components/schemas/DeleteSubmissionEntityResult'
       400:
         $ref: '#/components/responses/BadRequest'
       401:
@@ -123,7 +152,7 @@
 
 /submission/category/{categoryId}:
   get:
-    summary: Retrieve the Submissions for a category in this user session
+    summary: Retrieve a list of Submissions for a category in this user session
     tags:
       - Submission
     parameters:
@@ -140,7 +169,7 @@
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubmissionsSummaryResult'
+              $ref: '#/components/schemas/ListSubmissionsResult'
 
       401:
         $ref: '#/components/responses/UnauthorizedError'

--- a/apps/submission/src/controllers/submissionController.ts
+++ b/apps/submission/src/controllers/submissionController.ts
@@ -381,7 +381,10 @@ const deleteSubmissionById = validateRequest(
 				throw new lyricProvider.utils.errors.Forbidden('You do not have permission to delete this resource');
 			}
 
-			const response = lyricProvider.controllers.submission.delete(req, res, next);
+			const response = await lyricProvider.services.submission.deleteActiveSubmissionById(
+				submissionId,
+				user?.username || '',
+			);
 
 			return res.status(200).send(response);
 		} catch (error) {
@@ -444,17 +447,8 @@ const deleteEntityName = validateRequest(deleteEntityRequestSchema, async (req, 
 				throw new lyricProvider.utils.errors.NotFound(`Entity with name '${entityName}' not found`);
 			}
 
-			let records;
-
-			// Check of its array, if it is then we are removing index of SubmissionUpdateData[] | SubmissionDeleteData[]
-			if (Array.isArray(entityObj)) {
-				records = entityObj;
-			} else {
-				// if its not an array, then its of type SubmissionInsertData which we will remove index from DataRecord[]
-				records = entityObj.records;
-			}
-
-			if (records[index] === undefined) {
+			// Index should be between 0 and length -1
+			if (index < 0 || index >= entityObj.recordsCount) {
 				throw new lyricProvider.utils.errors.NotFound(`Index '${index}' not found`);
 			}
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
   apps/submission:
     dependencies:
       '@overture-stack/lyric':
-        specifier: ^0.14.0
-        version: 0.14.0(@types/pg@8.15.5)
+        specifier: ^0.15.0
+        version: 0.15.0(@types/pg@8.15.5)
       axios:
         specifier: ^1.10.0
         version: 1.12.2
@@ -1633,8 +1633,8 @@ packages:
       zod: 3.25.76
     dev: false
 
-  /@overture-stack/lyric-data-model@0.14.0(@types/pg@8.15.5):
-    resolution: {integrity: sha512-5bxnkad5Agl8IKoVjPdGMm7WwoWqZRouKOoLUhyPca/Sg+jEp8NwEHRikjA1aFdtpPFC4lYJdkAI17gaG6EOng==}
+  /@overture-stack/lyric-data-model@0.15.0(@types/pg@8.15.5):
+    resolution: {integrity: sha512-b0HDbw8pmgOYzdFRJ8vPlP6Y+F6KcuHOlu1AukxUDyIkOVcI1D892ndJfPGiIW3M/sjvE4xkeNbxD6Z8J1Br+Q==}
     dependencies:
       '@overture-stack/lectern-client': 2.0.0-beta.5
       copyfiles: 2.4.1
@@ -1667,12 +1667,12 @@ packages:
       - sqlite3
     dev: false
 
-  /@overture-stack/lyric@0.14.0(@types/pg@8.15.5):
-    resolution: {integrity: sha512-qws7Ngfu/x07AuO2v0aI1gXU8yeSdMP7u2sCt1JjB7N16mnbYBwcMbsVGo35ldlJWtdLFlVd4qTrTD4lm1hXbw==}
+  /@overture-stack/lyric@0.15.0(@types/pg@8.15.5):
+    resolution: {integrity: sha512-hOcmwPxN/lDHWG22K3yMbejk91Sy59ouGhcgFRbOiGO2eiTBeFs3uk5BE3DrXFosPV2F/gXy8x+RqQgRvM+c+A==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@overture-stack/lectern-client': 2.0.0-beta.5
-      '@overture-stack/lyric-data-model': 0.14.0(@types/pg@8.15.5)
+      '@overture-stack/lyric-data-model': 0.15.0(@types/pg@8.15.5)
       '@overture-stack/sqon-builder': 1.1.0
       dotenv: 16.6.1
       drizzle-orm: 0.29.5(@types/pg@8.15.5)(pg@8.16.3)


### PR DESCRIPTION
# Description
This PR updates Lyric version to make the Submission endpoints return a smaller ("summary") response payload.

## Details
- **Updated** @overture-stack/lyric version to latest 0.15.0
- **Updated** response on following endpoints to return a "summary" submission on response (instead of whole submission data):
  - `GET /submission/{submissionId}`
  - `GET /submission/category/{categoryId}`
- **Updated** response on following endpoints to return only the submissionId on response (instead of whole submission data):
  - `DELETE /submission/{submissionId}`
  - `DELETE /submission/{submissionId}/{actionType}`  
 - **New** endpoint `GET /submission/{submissionId}/details` to return whole Submission data.
 - OpenApi docs updated to reflect these changes.

## Issue related:
- https://github.com/Pan-Canadian-Genome-Library/clinical-submission/issues/130