### PR TITLE
Ensure all Lyric routes using PCGL Auth

### DIFF
--- a/apps/submission/src/api-docs/submission-api.yml
+++ b/apps/submission/src/api-docs/submission-api.yml
@@ -85,6 +85,8 @@
         description: Filters the Submission Data records by entity name. Must match names listed in the Submission Summary endpoint. If not provided, all entity names are returned.
       - $ref: '#/components/parameters/query/Page'
       - $ref: '#/components/parameters/query/PageSize'
+    security:
+      - bearerAuth: []
     responses:
       200:
         description: Full submission payload

--- a/apps/submission/src/routes/categoryRouter.ts
+++ b/apps/submission/src/routes/categoryRouter.ts
@@ -20,7 +20,6 @@
 import express, { json, Router, urlencoded } from 'express';
 
 import categoryController from '@/controllers/categoryController.js';
-import { lyricProvider } from '@/core/provider.js';
 import { authMiddleware } from '@/middleware/auth.js';
 
 export const categoryRouter: Router = (() => {
@@ -38,6 +37,5 @@ export const categoryRouter: Router = (() => {
 	router.get('/', categoryController.listAllCategories);
 	router.get('/:categoryId', categoryController.getCategoryById);
 
-	router.use('', lyricProvider.routers.category);
 	return router;
 })();

--- a/apps/submission/src/routes/data.ts
+++ b/apps/submission/src/routes/data.ts
@@ -20,7 +20,6 @@
 import express, { json, Router, urlencoded } from 'express';
 
 import dataController from '@/controllers/dataController.js';
-import { lyricProvider } from '@/core/provider.js';
 import { authMiddleware } from '@/middleware/auth.js';
 
 export const dataRouter: Router = (() => {
@@ -51,8 +50,6 @@ export const dataRouter: Router = (() => {
 		authMiddleware({ requireAdmin: true }),
 		dataController.getSubmittedDataStream,
 	);
-
-	router.use('', lyricProvider.routers.submittedData);
 
 	return router;
 })();

--- a/apps/submission/src/routes/dictionary.ts
+++ b/apps/submission/src/routes/dictionary.ts
@@ -35,7 +35,5 @@ export const dictionaryRouter: Router = (() => {
 	router.get('/category/:categoryId', lyricProvider.controllers.dictionary.getDictionaryJson);
 	router.get('/category/:categoryId/templates', lyricProvider.controllers.dictionary.downloadDataFileTemplates);
 
-	router.use('', lyricProvider.routers.dictionary);
-
 	return router;
 })();

--- a/apps/submission/src/routes/submission.ts
+++ b/apps/submission/src/routes/submission.ts
@@ -31,9 +31,11 @@ const upload = multer({ dest: '/tmp', limits: { fileSize: fileSizeLimit } });
 export const submissionRouter: Router = (() => {
 	const router = express.Router();
 
-	// Submission endpoints
+	// Submission by ID
 	router.get('/:submissionId', authMiddleware(), submissionController.getSubmissionById);
 	router.delete('/:submissionId', authMiddleware(), submissionController.deleteSubmissionById);
+
+	router.get('/:submissionId/details', authMiddleware(), submissionController.getSubmissionDetailsById);
 	router.delete('/:submissionId/:actionType', authMiddleware(), submissionController.deleteEntityName);
 
 	// Submissions by Category ID endpoints
@@ -51,7 +53,7 @@ export const submissionRouter: Router = (() => {
 		lyricProvider.controllers.submission.deleteSubmittedDataBySystemId,
 	);
 
-	router.use('', lyricProvider.routers.submission);
+	router.post('/category/:categoryId/commit/:submissionId', authMiddleware(), submissionController.commit);
 
 	return router;
 })();


### PR DESCRIPTION
- removes use of lyric routers through `router.use('', lyricProvider.routers.xRouter)` so that no routes are provided without custom pcgl auth handling
- Adds new controllers for submission getDetails and commit with PCGL Auth Handling