### PR TITLE
fix: Resolve Mismatch Drizzle Types from Study_translation Migration

### DIFF
--- a/apps/submission/package.json
+++ b/apps/submission/package.json
@@ -9,7 +9,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"studio": "NODE_OPTIONS='--import tsx' drizzle-kit studio",
-		"db:generate": "NODE_OPTIONS='--import tsx' drizzle-kit generate",
+		"db:generate": "NODE_OPTIONS='--import tsx' drizzle-kit generate --name=apply_composite_key_language_id_study_id",
 		"db:migrate": "NODE_OPTIONS='--import tsx' drizzle-kit migrate",
 		"\n==================  Build  ==================": "",
 		"build:compile": "rimraf dist && tsc",

--- a/apps/submission/package.json
+++ b/apps/submission/package.json
@@ -9,7 +9,7 @@
 	"main": "dist/index.js",
 	"scripts": {
 		"studio": "NODE_OPTIONS='--import tsx' drizzle-kit studio",
-		"db:generate": "NODE_OPTIONS='--import tsx' drizzle-kit generate --name=apply_composite_key_language_id_study_id",
+		"db:generate": "NODE_OPTIONS='--import tsx' drizzle-kit generate",
 		"db:migrate": "NODE_OPTIONS='--import tsx' drizzle-kit migrate",
 		"\n==================  Build  ==================": "",
 		"build:compile": "rimraf dist && tsc",

--- a/apps/submission/src/db/drizzle/0011_CUSTOM_revert_study_translations.sql
+++ b/apps/submission/src/db/drizzle/0011_CUSTOM_revert_study_translations.sql
@@ -1,0 +1,16 @@
+-- REVERT PREVIOUS MIGRATION
+
+-- Change name of existing tables and types to revert the migration
+ALTER TABLE "pcgl"."study_translations" RENAME TO "study_translations_custom";
+ALTER TYPE "pcgl"."languages" RENAME TO "languages_custom";
+DROP SEQUENCE IF EXISTS "pcgl"."study_translations_study_translation_id_seq" CASCADE;
+
+-- DROP new columns in study
+ALTER TABLE "pcgl"."study" DROP COLUMN "default_translation";
+
+-- Re-add the columns that were dropped from the study table as nullable
+ALTER TABLE "pcgl"."study" ADD COLUMN "study_description" text;
+ALTER TABLE "pcgl"."study" ADD COLUMN "program_name" varchar(255);
+ALTER TABLE "pcgl"."study" ADD COLUMN "keywords" text[];
+ALTER TABLE "pcgl"."study" ADD COLUMN "participant_criteria" text;
+ALTER TABLE "pcgl"."study" ADD COLUMN "funding_sources" text[];

--- a/apps/submission/src/db/drizzle/0012_re_add_study_translations.sql
+++ b/apps/submission/src/db/drizzle/0012_re_add_study_translations.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "pcgl"."languages" AS ENUM('en_ca', 'fr_ca');--> statement-breakpoint
+CREATE TABLE "pcgl"."study_translations" (
+	"study_translation_id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "pcgl"."study_translations_study_translation_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"study_id" text NOT NULL,
+	"language_id" "pcgl"."languages" NOT NULL,
+	"study_description" text NOT NULL,
+	"program_name" varchar(255),
+	"keywords" text[],
+	"participant_criteria" text,
+	"funding_sources" text[] NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "pcgl"."study" ADD COLUMN "default_translation" integer;--> statement-breakpoint
+ALTER TABLE "pcgl"."study" ADD CONSTRAINT "default_translation_fk" FOREIGN KEY ("default_translation") REFERENCES "pcgl"."study_translations"("study_translation_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pcgl"."study" DROP COLUMN "study_description";--> statement-breakpoint
+ALTER TABLE "pcgl"."study" DROP COLUMN "program_name";--> statement-breakpoint
+ALTER TABLE "pcgl"."study" DROP COLUMN "keywords";--> statement-breakpoint
+ALTER TABLE "pcgl"."study" DROP COLUMN "participant_criteria";--> statement-breakpoint
+ALTER TABLE "pcgl"."study" DROP COLUMN "funding_sources";

--- a/apps/submission/src/db/drizzle/0013_CUSTOM_copy_records_into_study_translations.sql
+++ b/apps/submission/src/db/drizzle/0013_CUSTOM_copy_records_into_study_translations.sql
@@ -1,0 +1,42 @@
+-- Copy records from the custom study_translations_custom table into the main study_translations table
+-- and update the default_translation field in the study table
+
+-- Alter the language_id column to use the pcgl.languages enum
+ALTER TABLE "pcgl"."study_translations_custom"
+    ALTER COLUMN "language_id" TYPE "pcgl"."languages" USING "language_id"::text::"pcgl"."languages";
+
+
+-- Insert data from the custom table into the main study_translations table
+INSERT INTO pcgl.study_translations (
+    study_id,
+    language_id,
+    study_description,
+    program_name,
+    keywords,
+    participant_criteria,
+    funding_sources,
+    created_at,
+    updated_at
+)
+SELECT
+    study_id,
+    language_id,
+    study_description,
+    program_name,
+    keywords,
+    participant_criteria,
+    funding_sources,
+    created_at,
+    updated_at
+FROM pcgl.study_translations_custom;
+
+
+-- Update the default_translation to point to the newly created translations
+UPDATE "pcgl"."study" studyTable
+SET default_translation = studyTranslationTable.study_translation_id
+FROM "pcgl"."study_translations" studyTranslationTable
+WHERE studyTable.study_id = studyTranslationTable.study_id AND studyTranslationTable.language_id = 'en_ca';
+
+
+-- Drop the custom table
+DROP TABLE pcgl.study_translations_custom;

--- a/apps/submission/src/db/drizzle/0014_apply_composite_key_language_id_study_id.sql
+++ b/apps/submission/src/db/drizzle/0014_apply_composite_key_language_id_study_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "pcgl"."study" ALTER COLUMN "default_translation" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "study_translations_study_id_language_id_index" ON "pcgl"."study_translations" USING btree ("study_id","language_id");

--- a/apps/submission/src/db/drizzle/meta/0011_snapshot.json
+++ b/apps/submission/src/db/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,436 @@
+{
+  "id": "297246d2-50c9-413d-be68-09ab6a018bc6",
+  "prevId": "5b6560ad-f9a7-4b18-acab-752e2df6e322",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLDA' || lpad(\n\t\tnextval('pcgl.dac_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dac_dac_name_unique": {
+          "name": "dac_dac_name_unique",
+          "columns": [
+            "dac_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "columns": [
+            "source_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_entity_name_unique": {
+          "name": "id_generation_config_entity_name_unique",
+          "columns": [
+            "entity_name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "columns": [
+            "sequence_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLST' || lpad(\n\t\tnextval('pcgl.study_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_study_name_unique": {
+          "name": "study_study_name_unique",
+          "columns": [
+            "study_name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "columns": [
+            "category_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "views": {},
+  "sequences": {
+    "pcgl.dac_id_seq": {
+      "name": "dac_id_seq",
+      "increment": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "startWith": "1",
+      "cache": "1",
+      "cycle": false,
+      "schema": "pcgl"
+    },
+    "pcgl.study_id_seq": {
+      "name": "study_id_seq",
+      "increment": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "startWith": "1",
+      "cache": "1",
+      "cycle": false,
+      "schema": "pcgl"
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/submission/src/db/drizzle/meta/0012_snapshot.json
+++ b/apps/submission/src/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,520 @@
+{
+  "id": "7859ceba-b2d6-41b6-9229-528add79419c",
+  "prevId": "297246d2-50c9-413d-be68-09ab6a018bc6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLDA' || lpad(\n\t\tnextval('pcgl.dac_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dac_dac_name_unique": {
+          "name": "dac_dac_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dac_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_entity_name_unique": {
+          "name": "id_generation_config_entity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_name"
+          ]
+        },
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLST' || lpad(\n\t\tnextval('pcgl.study_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_translation": {
+          "name": "default_translation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "default_translation_fk": {
+          "name": "default_translation_fk",
+          "tableFrom": "study",
+          "tableTo": "study_translations",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "default_translation"
+          ],
+          "columnsTo": [
+            "study_translation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_study_name_unique": {
+          "name": "study_study_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "study_name"
+          ]
+        },
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study_translations": {
+      "name": "study_translations",
+      "schema": "pcgl",
+      "columns": {
+        "study_translation_id": {
+          "name": "study_translation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "study_translations_study_translation_id_seq",
+            "schema": "pcgl",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "languages",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    },
+    "pcgl.languages": {
+      "name": "languages",
+      "schema": "pcgl",
+      "values": [
+        "en_ca",
+        "fr_ca"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "sequences": {
+    "pcgl.dac_id_seq": {
+      "name": "dac_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    },
+    "pcgl.study_id_seq": {
+      "name": "study_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/submission/src/db/drizzle/meta/0013_snapshot.json
+++ b/apps/submission/src/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,520 @@
+{
+  "id": "4e736d6a-7bf3-43c5-9c0f-4a809421b685",
+  "prevId": "7859ceba-b2d6-41b6-9229-528add79419c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLDA' || lpad(\n\t\tnextval('pcgl.dac_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dac_dac_name_unique": {
+          "name": "dac_dac_name_unique",
+          "columns": [
+            "dac_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "columns": [
+            "source_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_entity_name_unique": {
+          "name": "id_generation_config_entity_name_unique",
+          "columns": [
+            "entity_name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "columns": [
+            "sequence_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLST' || lpad(\n\t\tnextval('pcgl.study_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_translation": {
+          "name": "default_translation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "default_translation_fk": {
+          "name": "default_translation_fk",
+          "tableFrom": "study",
+          "columnsFrom": [
+            "default_translation"
+          ],
+          "tableTo": "study_translations",
+          "schemaTo": "pcgl",
+          "columnsTo": [
+            "study_translation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_study_name_unique": {
+          "name": "study_study_name_unique",
+          "columns": [
+            "study_name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "columns": [
+            "category_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study_translations": {
+      "name": "study_translations",
+      "schema": "pcgl",
+      "columns": {
+        "study_translation_id": {
+          "name": "study_translation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "study_translations_study_translation_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "pcgl",
+            "type": "always"
+          }
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "languages",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    },
+    "pcgl.languages": {
+      "name": "languages",
+      "schema": "pcgl",
+      "values": [
+        "en_ca",
+        "fr_ca"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "views": {},
+  "sequences": {
+    "pcgl.dac_id_seq": {
+      "name": "dac_id_seq",
+      "increment": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "startWith": "1",
+      "cache": "1",
+      "cycle": false,
+      "schema": "pcgl"
+    },
+    "pcgl.study_id_seq": {
+      "name": "study_id_seq",
+      "increment": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "startWith": "1",
+      "cache": "1",
+      "cycle": false,
+      "schema": "pcgl"
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/submission/src/db/drizzle/meta/0014_snapshot.json
+++ b/apps/submission/src/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,542 @@
+{
+  "id": "e2d2380f-1654-483a-8114-c9e33df62ab2",
+  "prevId": "4e736d6a-7bf3-43c5-9c0f-4a809421b685",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLDA' || lpad(\n\t\tnextval('pcgl.dac_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dac_dac_name_unique": {
+          "name": "dac_dac_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dac_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_entity_name_unique": {
+          "name": "id_generation_config_entity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_name"
+          ]
+        },
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLST' || lpad(\n\t\tnextval('pcgl.study_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_translation": {
+          "name": "default_translation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "default_translation_fk": {
+          "name": "default_translation_fk",
+          "tableFrom": "study",
+          "tableTo": "study_translations",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "default_translation"
+          ],
+          "columnsTo": [
+            "study_translation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_study_name_unique": {
+          "name": "study_study_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "study_name"
+          ]
+        },
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study_translations": {
+      "name": "study_translations",
+      "schema": "pcgl",
+      "columns": {
+        "study_translation_id": {
+          "name": "study_translation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "study_translations_study_translation_id_seq",
+            "schema": "pcgl",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "languages",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "study_translations_study_id_language_id_index": {
+          "name": "study_translations_study_id_language_id_index",
+          "columns": [
+            {
+              "expression": "study_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    },
+    "pcgl.languages": {
+      "name": "languages",
+      "schema": "pcgl",
+      "values": [
+        "en_ca",
+        "fr_ca"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "sequences": {
+    "pcgl.dac_id_seq": {
+      "name": "dac_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    },
+    "pcgl.study_id_seq": {
+      "name": "study_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/submission/src/db/drizzle/meta/_journal.json
+++ b/apps/submission/src/db/drizzle/meta/_journal.json
@@ -78,6 +78,34 @@
       "when": 1776692696148,
       "tag": "0010_CUSTOM_study_and_study_translations",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778014384893,
+      "tag": "0011_CUSTOM_revert_study_translations",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778022910938,
+      "tag": "0012_re_add_study_translations",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778023059203,
+      "tag": "0013_CUSTOM_copy_records_into_study_translations",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778024289895,
+      "tag": "0014_apply_composite_key_language_id_study_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/submission/src/db/schemas/studiesSchema.ts
+++ b/apps/submission/src/db/schemas/studiesSchema.ts
@@ -70,11 +70,6 @@ export const study = pcglSchema.table(
 			name: 'dac_id_fk',
 		}),
 		foreignKey({
-			columns: [table.study_id],
-			foreignColumns: [studyTranslations.study_id],
-			name: 'study_id_fk',
-		}),
-		foreignKey({
 			columns: [table.default_translation],
 			foreignColumns: [studyTranslations.study_translation_id],
 			name: 'default_translation_fk',
@@ -86,10 +81,6 @@ export const studyRelations = relations(study, ({ one }) => ({
 	dac_id: one(dac, {
 		fields: [study.dac_id],
 		references: [dac.dac_id],
-	}),
-	study_id: one(studyTranslations, {
-		fields: [study.study_id],
-		references: [studyTranslations.study_id],
 	}),
 	default_translation: one(studyTranslations, {
 		fields: [study.default_translation],

--- a/apps/submission/src/db/schemas/studyTranslationsSchema.ts
+++ b/apps/submission/src/db/schemas/studyTranslationsSchema.ts
@@ -17,21 +17,25 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { serial, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { integer, text, timestamp, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
 
 import { pcglSchema } from './generate.js';
 
 export const languages = pcglSchema.enum('languages', ['en_ca', 'fr_ca']);
 
-export const studyTranslations = pcglSchema.table('study_translations', {
-	study_translation_id: serial('study_translation_id').primaryKey(),
-	study_id: text().notNull(),
-	language_id: languages().notNull(),
-	study_description: text().notNull(),
-	program_name: varchar({ length: 255 }),
-	keywords: text().array(),
-	participant_criteria: text(),
-	funding_sources: text().array().notNull(),
-	created_at: timestamp().notNull().defaultNow(),
-	updated_at: timestamp(),
-});
+export const studyTranslations = pcglSchema.table(
+	'study_translations',
+	{
+		study_translation_id: integer().primaryKey().generatedAlwaysAsIdentity(),
+		study_id: text().notNull(),
+		language_id: languages().notNull(),
+		study_description: text().notNull(),
+		program_name: varchar({ length: 255 }),
+		keywords: text().array(),
+		participant_criteria: text(),
+		funding_sources: text().array().notNull(),
+		created_at: timestamp().notNull().defaultNow(),
+		updated_at: timestamp(),
+	},
+	(table) => [uniqueIndex().on(table.study_id, table.language_id)],
+);


### PR DESCRIPTION
### Description

[Custom Migration 0010](https://github.com/Pan-Canadian-Genome-Library/clinical-submission/blob/3f0018c975b8bc728ae29c5adc9625fde728dd2e/apps/submission/src/db/drizzle/0010_CUSTOM_study_and_study_translations.sql) created table study_translations and altered table study which works. But drizzle schemas do not recognize database changes(table creation, column alterations) and isn't properly captured in the snapshot. To properly sync drizzle and the database, we need to do the following to sync:

1. Generate CUSTOM `0011_CUSTOM_revert_study_translations` to revert previous 0010 changes
   1. Alter existing enum types to new name as well as change study_translation name to study_translation_custom
   2. Drop any existing sequences that was created from migration 0011
   3. Drop column `default_translation`
   4. Re-add `study_description`,`program_name`,`keywords`,`participant_criteria`,`funding_sources`
2. Generate from drizzle `0012_re_add_study_translations` to sync drizzle and db
   1. This will generate default_translation as nullable, this is for the next custom migration script to copy the records. We will re-apply the non-null constraint in 0014
4. Generate CUSTOM `0013_CUSTOM_copy_records_into_study_translations` to copy records from study_translation_custom to the new study_translation table.
5.  Generate from drizzle `0014_apply_composite_key_language_id_study_id` 
     1. Sets `default_translation` back to not NULL
     2. Creates unique index between `study_id` and `language_id`  

This should convert existing records that was altered by migration 0010 properly and also sync our drizzle db schemas defined in our codebase.