### PR TITLE
#180: Update Study Table DacId

### DIFF
--- a/apps/submission/src/api-docs/study-api.yml
+++ b/apps/submission/src/api-docs/study-api.yml
@@ -253,6 +253,49 @@
       500:
         $ref: '#/components/responses/ServerError'
 
+/study/dac/{studyId}:
+  patch:
+    summary: |
+      Update the DAC ID for a study by a study ID. (🔒 Admin only)
+    parameters:
+      - name: studyId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Unique identifier of the study in PCGL.
+    tags:
+      - Study
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              dacId:
+                type: string
+                description: DAC ID to update for the study.
+    responses:
+      200:
+        description: Returns the updated study record.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StudyResponse'
+      400:
+        $ref: '#/components/responses/BadRequest'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      403:
+        $ref: '#/components/responses/ForbiddenError'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+
 /study/translation/{studyId}:
   post:
     summary: Creates a new translation for an existing study. (🔒 Admin only)

--- a/apps/submission/src/api-docs/study-api.yml
+++ b/apps/submission/src/api-docs/study-api.yml
@@ -172,43 +172,21 @@
                 items:
                   type: string
                 description: List of researchers, institutions or companies involved in the study. Ex. FirstName LastName (if individual) or Organization full official name, Role.
-              dacId:
-                type: string
-                description: Unique identifier of the Data Access Committee (DAC) in PCGL to which the study is assigned.
               domain:
                 type: array
                 items:
                   type: string
                 description: List of specific scientific or clinical domains addressed by the study.
-              fundingSources:
-                type: array
-                items:
-                  type: string
-                description: List of organizations or agencies funding the study. Ex. Funder name, Grant number
-              keywords:
-                type: array
-                nullable: true
-                items:
-                  type: string
-                description: List of specific terms that describe the focus and content of the study.
               leadOrganizations:
                 type: array
                 items:
                   type: string
                 description: List of institutions or organizations leading the study.
-              participantCriteria:
-                type: string
-                nullable: true
-                description: Inclusion/exclusion criteria for participants (e.g., specific cancer type, age range).
               principalInvestigators:
                 type: array
                 items:
                   type: string
                 description: 'List of lead researchers responsible for the study. Ex. John Doe, Example Research Institute'
-              programName:
-                type: string
-                nullable: true
-                description: Indicate the overarching program the study belongs to (if applicable).
               publicationLinks:
                 type: array
                 items:
@@ -217,9 +195,6 @@
               studyName:
                 type: string
                 description: The official name of the study
-              studyDescription:
-                type: string
-                description: A detailed description of the study’s purpose, hypothesis, and design.
               status:
                 type: string
                 enum: ['Completed', 'Ongoing']

--- a/apps/submission/src/common/types/study.ts
+++ b/apps/submission/src/common/types/study.ts
@@ -44,7 +44,7 @@ export type AllowedLanguagesValues = (typeof AllowedLanguages)[keyof typeof Allo
 
 export type StudyDTO = {
 	studyId: string;
-	dacId: string;
+	dacId?: string | null;
 	studyName: string;
 	status: StudyStatusValues;
 	context: StudyContextValues;

--- a/apps/submission/src/common/validation/study-validation.ts
+++ b/apps/submission/src/common/validation/study-validation.ts
@@ -129,3 +129,12 @@ export const createStudyTranslation: RequestValidation<StudyTranslationFields, P
 		})
 		.strict(),
 };
+
+export const dacToStudy: RequestValidation<{ dacId: string }, ParsedQs, StudyIDParams> = {
+	pathParams: z.object({
+		studyId: stringNotEmpty,
+	}),
+	body: z.object({
+		dacId: stringNotEmpty,
+	}),
+};

--- a/apps/submission/src/common/validation/study-validation.ts
+++ b/apps/submission/src/common/validation/study-validation.ts
@@ -85,7 +85,20 @@ export const createStudy: RequestValidation<UpsertStudyFields, ParsedQs, ParamsD
 };
 
 export const updateStudy: RequestValidation<
-	Partial<Omit<StudyDTO, 'studyId' | 'updatedAt' | 'createdAt'>>,
+	Partial<
+		Omit<
+			StudyDTO,
+			| 'studyId'
+			| 'updatedAt'
+			| 'createdAt'
+			| 'defaultLanguage'
+			| 'studyDescription'
+			| 'fundingSources'
+			| 'keywords'
+			| 'participantCriteria'
+			| 'programName'
+		>
+	>,
 	ParsedQs,
 	StudyIDParams
 > = {
@@ -104,7 +117,7 @@ export const updateStudy: RequestValidation<
 		.partial()
 		.strict({
 			message:
-				'Unrecognized keys in object. Updating the following properties: studyId, updatedAt, createdAt, defaultLanguage, studyDescription, fundingSources, keywords, participantCriteria, or programName is disallowed.',
+				'Unrecognized keys in object. Properties defaultLanguage, studyDescription, fundingSources, keywords, participantCriteria, or programName should be updated in the update translations endpoint.',
 		}),
 };
 

--- a/apps/submission/src/common/validation/study-validation.ts
+++ b/apps/submission/src/common/validation/study-validation.ts
@@ -92,10 +92,20 @@ export const updateStudy: RequestValidation<
 	pathParams: z.object({
 		studyId: stringNotEmpty,
 	}),
-	body: createStudyProperties.partial().strict({
-		message:
-			'Unrecognized keys in object. Updating the following properties: studyId, updatedAt, or createdAt is disallowed.',
-	}),
+	body: createStudyProperties
+		.omit({
+			defaultLanguage: true,
+			studyDescription: true,
+			fundingSources: true,
+			keywords: true,
+			participantCriteria: true,
+			programName: true,
+		})
+		.partial()
+		.strict({
+			message:
+				'Unrecognized keys in object. Updating the following properties: studyId, updatedAt, createdAt, defaultLanguage, studyDescription, fundingSources, keywords, participantCriteria, or programName is disallowed.',
+		}),
 };
 
 export const listAllStudies: RequestValidation<object, PaginationParams, ParamsDictionary> = {

--- a/apps/submission/src/common/validation/study-validation.ts
+++ b/apps/submission/src/common/validation/study-validation.ts
@@ -45,7 +45,7 @@ const ALLOWED_DOMAINS = [
 
 const createStudyProperties = z
 	.object({
-		dacId: stringNotEmpty,
+		dacId: z.string().optional().nullable(),
 		defaultLanguage: z.nativeEnum(AllowedLanguages),
 		studyName: stringNotEmpty,
 		studyDescription: stringNotEmpty,

--- a/apps/submission/src/controllers/studyController.ts
+++ b/apps/submission/src/controllers/studyController.ts
@@ -89,9 +89,7 @@ export const createNewStudy = validateRequest(createStudy, async (req, res, next
 				if (studyData.dacId) {
 					const dacFound = await getDacById(studyData.dacId);
 					if (!dacFound) {
-						throw new lyricProvider.utils.errors.BadRequest(
-							`${studyData.dacId} does not appear to be a valid DAC ID, please ensure this DAC exists prior to creating a study.`,
-						);
+						throw new lyricProvider.utils.errors.BadRequest(`${studyData.dacId} is not a valid DAC ID.`);
 					}
 				}
 

--- a/apps/submission/src/controllers/studyController.ts
+++ b/apps/submission/src/controllers/studyController.ts
@@ -84,11 +84,14 @@ export const createNewStudy = validateRequest(createStudy, async (req, res, next
 					);
 				}
 
-				const dacFound = await getDacById(studyData.dacId);
-				if (!dacFound) {
-					throw new lyricProvider.utils.errors.BadRequest(
-						`${studyData.dacId} does not appear to be a valid DAC ID, please ensure this DAC record exists prior to creating a study.`,
-					);
+				// If the dacId does exist, make sure it is valid dac record
+				if (studyData.dacId) {
+					const dacFound = await getDacById(studyData.dacId);
+					if (!dacFound) {
+						throw new lyricProvider.utils.errors.BadRequest(
+							`${studyData.dacId} does not appear to be a valid DAC ID, please ensure this DAC exists prior to creating a study.`,
+						);
+					}
 				}
 
 				const results = await createStudy(studyData, transaction);

--- a/apps/submission/src/controllers/studyController.ts
+++ b/apps/submission/src/controllers/studyController.ts
@@ -20,6 +20,7 @@
 import {
 	createStudy,
 	createStudyTranslation,
+	dacToStudy,
 	getOrDeleteStudyByID,
 	listAllStudies,
 	updateStudy,
@@ -195,6 +196,40 @@ export const updateStudyTranslationById = validateRequest(createStudyTranslation
 		const results = await studyRepo.updateStudyTranslation({ ...translationData, studyId });
 
 		res.status(200).send(results);
+		return;
+	} catch (exception) {
+		next(exception);
+	}
+});
+
+export const addDacIdToStudy = validateRequest(dacToStudy, async (req, res, next) => {
+	try {
+		const { studyId } = req.params;
+		const { dacId } = req.body;
+
+		const db = getDbInstance();
+		const studyRepo = studyService(db);
+		const dacRepo = dacService(db);
+
+		const studyFound = await studyRepo.getStudyById(studyId);
+
+		if (!studyFound) {
+			throw new lyricProvider.utils.errors.NotFound(`No Study with ID - ${studyId} found.`);
+		}
+
+		if (studyFound.dacId !== null) {
+			throw new lyricProvider.utils.errors.StatusConflict(`Study with ID - ${studyId} already has a DAC ID.`);
+		}
+
+		const dacFound = await dacRepo.getDacById(dacId);
+
+		if (!dacFound) {
+			throw new lyricProvider.utils.errors.NotFound(`No DAC with ID - ${dacId} found.`);
+		}
+
+		const updatedStudy = await studyRepo.updateStudyDacId({ studyId, dacId });
+
+		res.status(200).send(updatedStudy);
 		return;
 	} catch (exception) {
 		next(exception);

--- a/apps/submission/src/db/drizzle/0015_study_make_dacId_nullable.sql
+++ b/apps/submission/src/db/drizzle/0015_study_make_dacId_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pcgl"."study" ALTER COLUMN "dac_id" DROP NOT NULL;

--- a/apps/submission/src/db/drizzle/meta/0015_snapshot.json
+++ b/apps/submission/src/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,542 @@
+{
+  "id": "6da13470-c2bf-41e9-878d-35d1b29f9e18",
+  "prevId": "e2d2380f-1654-483a-8114-c9e33df62ab2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "pcgl.dac": {
+      "name": "dac",
+      "schema": "pcgl",
+      "columns": {
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLDA' || lpad(\n\t\tnextval('pcgl.dac_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_name": {
+          "name": "dac_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dac_description": {
+          "name": "dac_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pcgl_dac": {
+          "name": "is_pcgl_dac",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dac_dac_name_unique": {
+          "name": "dac_dac_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dac_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.generated_identifiers": {
+      "name": "generated_identifiers",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_identifiers_config_id_id_generation_config_id_fk": {
+          "name": "generated_identifiers_config_id_id_generation_config_id_fk",
+          "tableFrom": "generated_identifiers",
+          "tableTo": "id_generation_config",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "generated_identifiers_source_hash_unique": {
+          "name": "generated_identifiers_source_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.id_generation_config": {
+      "name": "id_generation_config",
+      "schema": "pcgl",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "padding_length": {
+          "name": "padding_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_name": {
+          "name": "sequence_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_start": {
+          "name": "sequence_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "id_generation_config_entity_name_unique": {
+          "name": "id_generation_config_entity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_name"
+          ]
+        },
+        "id_generation_config_sequence_name_unique": {
+          "name": "id_generation_config_sequence_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sequence_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study": {
+      "name": "study",
+      "schema": "pcgl",
+      "columns": {
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "\n\t'PCGLST' || lpad(\n\t\tnextval('pcgl.study_id_seq')::text,\n\t\t4,\n\t\t'0'\n\t)\n"
+        },
+        "dac_id": {
+          "name": "dac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_translation": {
+          "name": "default_translation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_name": {
+          "name": "study_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "study_status",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "study_context",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_investigators": {
+          "name": "principal_investigators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lead_organizations": {
+          "name": "lead_organizations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collaborators": {
+          "name": "collaborators",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publication_links": {
+          "name": "publication_links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dac_id_fk": {
+          "name": "dac_id_fk",
+          "tableFrom": "study",
+          "tableTo": "dac",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "dac_id"
+          ],
+          "columnsTo": [
+            "dac_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "default_translation_fk": {
+          "name": "default_translation_fk",
+          "tableFrom": "study",
+          "tableTo": "study_translations",
+          "schemaTo": "pcgl",
+          "columnsFrom": [
+            "default_translation"
+          ],
+          "columnsTo": [
+            "study_translation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "study_study_name_unique": {
+          "name": "study_study_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "study_name"
+          ]
+        },
+        "study_category_id_unique": {
+          "name": "study_category_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "pcgl.study_translations": {
+      "name": "study_translations",
+      "schema": "pcgl",
+      "columns": {
+        "study_translation_id": {
+          "name": "study_translation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "study_translations_study_translation_id_seq",
+            "schema": "pcgl",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "study_id": {
+          "name": "study_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "languages",
+          "typeSchema": "pcgl",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "study_description": {
+          "name": "study_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keywords": {
+          "name": "keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_criteria": {
+          "name": "participant_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "funding_sources": {
+          "name": "funding_sources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "study_translations_study_id_language_id_index": {
+          "name": "study_translations_study_id_language_id_index",
+          "columns": [
+            {
+              "expression": "study_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "pcgl.study_context": {
+      "name": "study_context",
+      "schema": "pcgl",
+      "values": [
+        "Clinical",
+        "Research"
+      ]
+    },
+    "pcgl.study_status": {
+      "name": "study_status",
+      "schema": "pcgl",
+      "values": [
+        "Ongoing",
+        "Completed"
+      ]
+    },
+    "pcgl.languages": {
+      "name": "languages",
+      "schema": "pcgl",
+      "values": [
+        "en_ca",
+        "fr_ca"
+      ]
+    }
+  },
+  "schemas": {
+    "pcgl": "pcgl"
+  },
+  "sequences": {
+    "pcgl.dac_id_seq": {
+      "name": "dac_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    },
+    "pcgl.study_id_seq": {
+      "name": "study_id_seq",
+      "schema": "pcgl",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9999",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/submission/src/db/drizzle/meta/_journal.json
+++ b/apps/submission/src/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778024289895,
       "tag": "0014_apply_composite_key_language_id_study_id",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1779199615650,
+      "tag": "0015_study_make_dacId_nullable",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/submission/src/db/schemas/studiesSchema.ts
+++ b/apps/submission/src/db/schemas/studiesSchema.ts
@@ -49,7 +49,7 @@ export const study = pcglSchema.table(
 	'study',
 	{
 		study_id: text().primaryKey().default(studyIdDefault),
-		dac_id: text().notNull(),
+		dac_id: text(),
 		default_translation: integer().notNull(),
 		study_name: varchar({ length: 255 }).unique().notNull(),
 		status: studyStatus().notNull(),

--- a/apps/submission/src/routes/study.ts
+++ b/apps/submission/src/routes/study.ts
@@ -20,6 +20,7 @@
 import express, { json, Router, urlencoded } from 'express';
 
 import {
+	addDacIdToStudy,
 	createNewStudy,
 	createStudyTranslationById,
 	deleteStudyById,
@@ -41,6 +42,8 @@ export const studyRouter: Router = (() => {
 	router.post('/', authMiddleware({ requireAdmin: true }), createNewStudy);
 	router.delete('/:studyId', authMiddleware({ requireAdmin: true }), deleteStudyById);
 	router.patch('/:studyId', authMiddleware({ requireAdmin: true }), updateStudyById);
+	router.patch('/dac/:studyId', authMiddleware({ requireAdmin: true }), addDacIdToStudy);
+
 	router.post('/translation/:studyId', authMiddleware({ requireAdmin: true }), createStudyTranslationById);
 	router.patch('/translation/:studyId', authMiddleware({ requireAdmin: true }), updateStudyTranslationById);
 

--- a/apps/submission/src/service/studyService.ts
+++ b/apps/submission/src/service/studyService.ts
@@ -267,7 +267,6 @@ const studyService = (db: PostgresDb) => ({
 			const updatedRecord = await db
 				.update(study)
 				.set({
-					dac_id: studyData.dacId,
 					study_name: studyData.studyName,
 					status: studyData.status,
 					context: studyData.context,

--- a/apps/submission/src/service/studyService.ts
+++ b/apps/submission/src/service/studyService.ts
@@ -419,6 +419,29 @@ const studyService = (db: PostgresDb) => ({
 			}
 		}
 	},
+	updateStudyDacId: async (studyData: { studyId: string; dacId: string }): Promise<StudyResponse | undefined> => {
+		try {
+			const updatedRecord = await db
+				.update(study)
+				.set({
+					dac_id: studyData.dacId,
+					updated_at: sql`NOW()`,
+				})
+				.where(eq(study.study_id, studyData.studyId))
+				.returning();
+
+			if (updatedRecord[0]) {
+				return await convertFromRecordToStudyResponse(updatedRecord[0], db);
+			}
+			return;
+		} catch (error) {
+			logger.error(error, 'Error at updateStudy in StudyService');
+
+			throw new lyricProvider.utils.errors.InternalServerError(
+				'Something went wrong while updating the requested study. Please try again later.',
+			);
+		}
+	},
 });
 
 export { studyService };

--- a/apps/submission/src/service/studyService.ts
+++ b/apps/submission/src/service/studyService.ts
@@ -435,10 +435,10 @@ const studyService = (db: PostgresDb) => ({
 			}
 			return;
 		} catch (error) {
-			logger.error(error, 'Error at updateStudy in StudyService');
+			logger.error(error, 'Error at updateStudyDacId in StudyService');
 
 			throw new lyricProvider.utils.errors.InternalServerError(
-				'Something went wrong while updating the requested study. Please try again later.',
+				"Something went wrong while updating the requested study's DAC ID. Please try again later.",
 			);
 		}
 	},


### PR DESCRIPTION
### Description

Update the study table column `dac_id` so it is a nullable field. Also create an endpoint to selectively update the dac id for a study that does not have an existing dacId record. 

### Changes


- Generate migration for removing `dacId` non null constraint
- Add `PATCH /study/dac/{studyId}`
- Update `PATCH /study/{studyId}`
   - Remove the ability to update `dacId` from this endpoint as well as the validations
   - Remove redundant body params from swagger docs
  