### PR TITLE
#181 Ability to Automatically Add New Studies in Authz

### DIFF
--- a/apps/submission/src/controllers/studyController.ts
+++ b/apps/submission/src/controllers/studyController.ts
@@ -27,6 +27,11 @@ import {
 } from '@/common/validation/study-validation.js';
 import { lyricProvider } from '@/core/provider.js';
 import { getDbInstance } from '@/db/index.js';
+import {
+	createStudy as createAuthzStudy,
+	extractAccessTokenFromHeader,
+	getStudyById as getAuthzStudyById,
+} from '@/external/pcglAuthZClient.js';
 import { validateRequest } from '@/middleware/requestValidation.js';
 import dacService from '@/service/dacService.js';
 import { studyService } from '@/service/studyService.js';
@@ -72,37 +77,44 @@ export const getStudyById = validateRequest(getOrDeleteStudyByID, async (req, re
 export const createNewStudy = validateRequest(createStudy, async (req, res, next) => {
 	try {
 		const studyData = req.body;
+		const accessToken = extractAccessTokenFromHeader(req);
 		const db = getDbInstance();
 		const { getStudyByName, createStudy } = studyService(db);
 		const { getDacById } = dacService(db);
 
+		if (!accessToken) {
+			throw new lyricProvider.utils.errors.Forbidden('Unauthorized: No access token provided');
+		}
+
 		const studyTransaction = await db.transaction(async (transaction) => {
-			try {
-				const studyFound = await getStudyByName(studyData.studyName);
-				if (studyFound) {
-					throw new lyricProvider.utils.errors.BadRequest(
-						`${studyData.studyName} already exists in studies. Study name must be unique.`,
-					);
-				}
-
-				// If the dacId does exist, make sure it is valid dac record
-				if (studyData.dacId) {
-					const dacFound = await getDacById(studyData.dacId);
-					if (!dacFound) {
-						throw new lyricProvider.utils.errors.BadRequest(`${studyData.dacId} is not a valid DAC ID.`);
-					}
-				}
-
-				const results = await createStudy(studyData, transaction);
-
-				if (!results) {
-					throw new lyricProvider.utils.errors.BadRequest(`Unable to create study with provided data.`);
-				}
-
-				return results;
-			} catch (exception) {
-				next(exception);
+			const studyFound = await getStudyByName(studyData.studyName);
+			if (studyFound) {
+				throw new lyricProvider.utils.errors.BadRequest(
+					`${studyData.studyName} already exists in studies. Study name must be unique.`,
+				);
 			}
+
+			// If the dacId does exist, make sure it is valid dac record
+			if (studyData.dacId) {
+				const dacFound = await getDacById(studyData.dacId);
+				if (!dacFound) {
+					throw new lyricProvider.utils.errors.BadRequest(`${studyData.dacId} is not a valid DAC ID.`);
+				}
+			}
+
+			const results = await createStudy(studyData, transaction);
+
+			if (!results) {
+				throw new lyricProvider.utils.errors.BadRequest(`Unable to create study with provided data.`);
+			}
+
+			const authzStudy = await getAuthzStudyById(results.studyId, accessToken);
+
+			if (!authzStudy) {
+				await createAuthzStudy(results.studyId, accessToken);
+			}
+
+			return results;
 		});
 
 		res.status(201).send(studyTransaction);

--- a/apps/submission/src/external/pcglAuthZClient.ts
+++ b/apps/submission/src/external/pcglAuthZClient.ts
@@ -230,3 +230,61 @@ export const extractAccessTokenFromHeader = (req: Request): string | undefined =
 const extractUserGroups = ({ groups }: Groups): string[] => {
 	return groups.map((currentGroup) => currentGroup.name);
 };
+
+export const getStudyById = async (studyId: string, token: string) => {
+	const { AUTHZ_ENDPOINT } = authConfig;
+
+	const headers = new Headers({
+		Authorization: `Bearer ${token}`,
+		'Content-Type': 'application/json',
+	});
+
+	const url = urlJoin(AUTHZ_ENDPOINT, `/study/${studyId}`);
+	const response = await fetch(url, {
+		method: 'GET',
+		headers,
+	});
+
+	if (response.status === 404) {
+		return;
+	}
+
+	if (!response.ok) {
+		throw new lyricProvider.utils.errors.InternalServerError(
+			`Failed to fetch study in Authz with status ${response.status}`,
+		);
+	}
+
+	return await response.json();
+};
+
+export const createStudy = async (studyId: string, token: string) => {
+	const todaysDate = new Date().toISOString();
+
+	const studyData = {
+		study_id: studyId,
+		data_submitters: [],
+		team_members: [],
+		creation_date: todaysDate,
+	};
+
+	const { AUTHZ_ENDPOINT } = authConfig;
+
+	const headers = new Headers({
+		Authorization: `Bearer ${token}`,
+		'Content-Type': 'application/json',
+	});
+
+	const url = urlJoin(AUTHZ_ENDPOINT, '/study');
+	const response = await fetch(url, {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(studyData),
+	});
+
+	if (!response.ok) {
+		throw new lyricProvider.utils.errors.InternalServerError(
+			`Failed to create study in Authz with status ${response.status}`,
+		);
+	}
+};


### PR DESCRIPTION
# Summary
When creating a new study, `Clinical` now verifies its existence in `AuthZ` and creates it if missing, ensuring automated data consistency across services.

## Description
- **User's token based operations**: Using user's token to call Authz operations in following scenarios.
- **Existence check before creation** Verify in Authz for studyId existence by calling `GET /study/{studyId}`
- **Conditional creation in AuthZ:** If the study doesn't exist in AuthZ (404 response), call `POST /study` to create it with the generated study ID.

## Ticket
- https://github.com/Pan-Canadian-Genome-Library/Roadmap/issues/181