### PR TITLE
Update Lyric `0.19.0`

### DIFF
--- a/apps/submission/package.json
+++ b/apps/submission/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@clinical-submission/validation": "workspace:^",
-		"@overture-stack/lyric": "^0.17.0",
+		"@overture-stack/lyric": "^0.19.0",
 		"axios": "^1.10.0",
 		"bytes": "^3.1.2",
 		"cors": "^2.8.5",

--- a/apps/submission/src/api-docs/audit-api.yml
+++ b/apps/submission/src/api-docs/audit-api.yml
@@ -4,11 +4,7 @@
     tags:
       - Audit
     parameters:
-      - name: categoryId
-        in: path
-        description: ID of the Category
-        type: string
-        required: true
+      - $ref: '#/components/parameters/path/CategoryId'
       - name: organization
         in: path
         description: Name of the Organization

--- a/apps/submission/src/api-docs/categories-api.yml
+++ b/apps/submission/src/api-docs/categories-api.yml
@@ -22,15 +22,16 @@
 /category/{categoryId}:
   get:
     summary: Retrieve details of a specific category
+    description: >-
+      Accepts either the category's numeric id or its alias. Aliases are rejected outright if
+      they're purely numeric, so this collision shouldn't arise through normal API usage; as a
+      defense in depth, if a value could still match both a category's numeric id and a different
+      category's alias, the numeric id wins, so a category can never become unreachable by its own
+      id.
     tags:
       - Category
     parameters:
-      - name: categoryId
-        in: path
-        required: true
-        schema:
-          type: string
-        description: ID of the category
+      - $ref: '#/components/parameters/path/CategoryId'
     responses:
       200:
         description: Category Details
@@ -40,6 +41,85 @@
               $ref: '#/components/schemas/CategoryDetails'
       400:
         $ref: '#/components/responses/BadRequest'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+/category/{categoryId}/alias:
+  put:
+    summary: Assign an alias to a category (🔒 Admin only)
+    description: >-
+      Sets a category's alias. Succeeds when the category has no alias yet, or when the requested
+      alias matches its existing one (idempotent retry). Changing an already-set alias to a
+      different value isn't supported yet, use DELETE then PUT instead.
+    tags:
+      - Category
+    parameters:
+      - $ref: '#/components/parameters/path/CategoryId'
+    security:
+      - bearerAuth: []
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              alias:
+                type: string
+                description: >-
+                  A human-readable identifier for the category, usable anywhere a categoryId is
+                  accepted. It isn't permanent: it can be cleared or reassigned to a different
+                  category later. Letters, numbers, hyphens, underscores, and periods only. A
+                  purely numeric value (e.g. `5`) is rejected, since it could collide with a
+                  category's numeric id; a value containing a decimal point (e.g. `2.5`) is
+                  allowed, including as a data version label.
+            required:
+              - alias
+    responses:
+      200:
+        description: The category, with its alias set
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategorySummary'
+      400:
+        $ref: '#/components/responses/BadRequest'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
+      403:
+        $ref: '#/components/responses/ForbiddenError'
+      404:
+        $ref: '#/components/responses/NotFound'
+      409:
+        $ref: '#/components/responses/StatusConflict'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+  delete:
+    summary: Clear a category's alias (🔒 Admin only)
+    description: >-
+      Removes a category's alias, freeing it for reuse. Idempotent: a category with no alias
+      returns 200 rather than an error.
+    tags:
+      - Category
+    parameters:
+      - $ref: '#/components/parameters/path/CategoryId'
+    security:
+      - bearerAuth: []
+    responses:
+      200:
+        description: The category, with its alias cleared
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CategorySummary'
+      401:
+        $ref: '#/components/responses/UnauthorizedError'
       404:
         $ref: '#/components/responses/NotFound'
       500:

--- a/apps/submission/src/api-docs/dictionary-api.yml
+++ b/apps/submission/src/api-docs/dictionary-api.yml
@@ -62,9 +62,17 @@
         $ref: '#/components/responses/ServerError'
 /dictionary/register:
   post:
-    summary: Associates the provided dictionary and version from the Dictionary Manager with a new category linked to the specified study ID. (🔒 Admin only)
+    summary: Associates the provided dictionary and version from the Dictionary Manager with a new category linked to the specified study ID. Creates the category if it does not exist, or updates its active dictionary and triggers a data migration to validate and update existing data against the new dictionary. (🔒 Admin only)
     tags:
       - Dictionary
+    parameters:
+      - name: force
+        description: Retries migration for this category only when the same dictionary is already registered and the most recent migration previously failed. If there is no previous failed migration, this flag is ignored.
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
     requestBody:
       content:
         application/json:

--- a/apps/submission/src/api-docs/dictionary-api.yml
+++ b/apps/submission/src/api-docs/dictionary-api.yml
@@ -11,7 +11,7 @@
         required: true
         schema:
           type: string
-        description: The ID of the category containing the dictionary
+        description: Numeric ID or alias of the category containing the dictionary
     responses:
       200:
         description: Dictionary schema JSON
@@ -38,7 +38,7 @@
         required: true
         schema:
           type: string
-        description: The ID of the category containing the dictionary
+        description: Numeric ID or alias of the category containing the dictionary
       - name: fileType
         in: query
         required: false

--- a/apps/submission/src/api-docs/dictionary-api.yml
+++ b/apps/submission/src/api-docs/dictionary-api.yml
@@ -10,7 +10,7 @@
         in: path
         required: true
         schema:
-          type: integer
+          type: string
         description: The ID of the category containing the dictionary
     responses:
       200:
@@ -37,7 +37,7 @@
         in: path
         required: true
         schema:
-          type: integer
+          type: string
         description: The ID of the category containing the dictionary
       - name: fileType
         in: query
@@ -71,12 +71,26 @@
           schema:
             type: object
             properties:
-              studyId:
+              alias:
                 type: string
-                description: The unique identifier of the study, which must be already created by the Data Admin.
+                description: >-
+                  An optional, human-readable identifier for the category, usable anywhere a
+                  categoryId is accepted, in place of the numeric id. Doesn't change on its own the
+                  way an auto-generated token might, though it can be cleared or reassigned via
+                  PUT/DELETE /category/{categoryId}/alias, it isn't permanent the way the numeric id
+                  is. Letters, numbers, hyphens, underscores, and periods only; an empty string is
+                  treated as not provided. A purely numeric value (e.g. `5`) is rejected, since it
+                  could collide with a category's numeric id; a value containing a decimal point
+                  (e.g. `2.5`) is allowed, including as a data version label. Can only be set here
+                  at category creation; supplying it while registering onto an existing category
+                  returns 400. Use PUT/DELETE /category/{categoryId}/alias to add or remove one
+                  afterward; changing an already-set alias isn't supported yet.
               categoryName:
                 type: string
                 description: A user-defined classification to group and organize data based on shared characteristics or criteria
+              defaultCentricEntity:
+                type: string
+                description: The default centric entity name
               dictionaryName:
                 type: string
                 description: A matching Dictionary Name defined on Dictionary Manager
@@ -84,9 +98,9 @@
                 type: string
                 example: '1.0'
                 description: A matching Dictionary Version defined on Dictionary Manager
-              defaultCentricEntity:
+              studyId:
                 type: string
-                description: The default centric entity name
+                description: The unique identifier of the study, which must be already created by the Data Admin.
             required:
               - categoryName
               - dictionaryName

--- a/apps/submission/src/api-docs/migration-api.yml
+++ b/apps/submission/src/api-docs/migration-api.yml
@@ -1,0 +1,75 @@
+# Description of Migration API
+
+/migration/category/{categoryId}:
+  get:
+    summary: Retrieve the Migrations for a category
+    tags:
+      - Migration
+    parameters:
+      - $ref: '#/components/parameters/path/CategoryId'
+      - $ref: '#/components/parameters/query/Page'
+      - $ref: '#/components/parameters/query/PageSize'
+    responses:
+      200:
+        description: List of Migrations
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListMigrationsResult'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+/migration/{migrationId}:
+  get:
+    summary: Get Migration general information by ID
+    tags:
+      - Migration
+    parameters:
+      - $ref: '#/components/parameters/path/MigrationId'
+    responses:
+      200:
+        description: Migration general information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MigrationResult'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'
+
+/migration/{migrationId}/records:
+  get:
+    summary: Retrieve the records for a migration
+    tags:
+      - Migration
+    parameters:
+      - $ref: '#/components/parameters/path/MigrationId'
+      - isInvalid:
+        description: Optional query parameter to filter results to include only invalid records. Default is to include all records.
+        name: isInvalid
+        in: query
+        schema:
+          type: boolean
+        required: false
+      - $ref: '#/components/parameters/query/Page'
+      - $ref: '#/components/parameters/query/PageSize'
+    responses:
+      200:
+        description: List of Migration records
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListMigrationRecordsResult'
+      404:
+        $ref: '#/components/responses/NotFound'
+      500:
+        $ref: '#/components/responses/ServerError'
+      503:
+        $ref: '#/components/responses/ServiceUnavailableError'

--- a/apps/submission/src/api-docs/parameters.yml
+++ b/apps/submission/src/api-docs/parameters.yml
@@ -30,6 +30,13 @@ components:
         schema:
           type: string
         required: true
+      MigrationId:
+        name: migrationId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The ID of the Migration
       Organization:
         name: organization
         in: path

--- a/apps/submission/src/api-docs/parameters.yml
+++ b/apps/submission/src/api-docs/parameters.yml
@@ -7,7 +7,8 @@ components:
         required: true
         schema:
           type: string
-        description: ID of the category to which the data belongs
+        description: >-
+          Numeric ID or alias of the category to which the data belongs.
       DacId:
         name: dacId
         in: path

--- a/apps/submission/src/api-docs/schemas.yml
+++ b/apps/submission/src/api-docs/schemas.yml
@@ -141,16 +141,7 @@ components:
       type: object
       properties:
         pagination:
-          type: object
-          properties:
-            currentPage:
-              type: number
-            pageSize:
-              type: number
-            totalPages:
-              type: number
-            totalRecords:
-              type: number
+          $ref: '#/components/schemas/Pagination'
         records:
           type: array
           items:
@@ -165,7 +156,7 @@ components:
         event:
           type: string
           description: Type of event
-          enum: ['UPDATE', 'DELETE']
+          enum: ['UPDATE', 'DELETE', 'MIGRATION']
         dataDiff:
           type: object
           description: Captures the state of the data before the change as `old` and after the change as `new`
@@ -306,16 +297,7 @@ components:
       type: object
       properties:
         pagination:
-          type: object
-          properties:
-            currentPage:
-              type: number
-            pageSize:
-              type: number
-            totalPages:
-              type: number
-            totalRecords:
-              type: number
+          $ref: '#/components/schemas/Pagination'
         records:
           type: array
           items:
@@ -354,6 +336,10 @@ components:
         dictionary:
           type: object
           description: Schema of the Dictionary
+        migrationId:
+          type: string
+          description: ID of the Migration if applicable
+          allowEmptyValue: true
         name:
           type: string
           description: Name of the Dictionary
@@ -570,24 +556,136 @@ components:
           items:
             $ref: '#/components/schemas/ValidationError'
 
+    ListMigrationRecordsResult:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/MigrationChangeHistoryRecord'
+
+    ListMigrationsResult:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/MigrationResult'
+
+    MigrationChangeHistoryRecord:
+      type: object
+      properties:
+        entityName:
+          type: string
+          description: Name of the Entity
+        errors:
+          type: array
+          description: List of validation errors related to the change if applicable
+          items:
+            $ref: '#/components/schemas/ValidationError'
+        dataDiff:
+          type: object
+          description: Captures the state of the data before the change as `old` and after the change as `new`
+        newIsValid:
+          type: boolean
+          description: New  data isValid value
+        oldIsValid:
+          type: boolean
+          description: Old data isValid value
+        organization:
+          type: string
+          description: Name of the Organization
+        systemId:
+          type: string
+          description: The unique identifier of the record changed
+        createdAt:
+          type: string
+          description: Date and time of creation
+        createdBy:
+          type: string
+          description: User name who updated the submission
+
+    MigrationResult:
+      type: object
+      properties:
+        id:
+          type: number
+          description: ID of the Migration
+        category:
+          type: object
+          description: Category this dictionary belongs in
+          properties:
+            id:
+              type: number
+            name:
+              type: string
+        fromDictionary:
+          type: object
+          description: Previous Dictionary used in this category
+          properties:
+            name:
+              type: string
+            version:
+              type: string
+        toDictionary:
+          type: object
+          description: New Dictionary used in this category
+          properties:
+            name:
+              type: string
+            version:
+              type: string
+        submissionId:
+          type: number
+          description: ID of the Submission used for the migration
+        invalidRecords:
+          type: number
+          description: Number of invalid records during the migration
+        status:
+          type: string
+          description: Status of the Migration
+          enum: ['IN-PROGRESS', 'COMPLETED', 'FAILED']
+        retries:
+          type: number
+          description: Number of times the migration has run. When a migration fails, it can be retried by registering again the same dictionary.
+        createdAt:
+          type: string
+          description: Date and time of creation
+        createdBy:
+          type: string
+          description: User name who created the migration
+        updatedAt:
+          type: string
+          description: Date and time of latest update
+        updatedBy:
+          type: string
+          description: User name who last updated the migration
+
     ListSubmissionsResult:
       type: object
       properties:
         pagination:
-          type: object
-          properties:
-            currentPage:
-              type: number
-            pageSize:
-              type: number
-            totalPages:
-              type: number
-            totalRecords:
-              type: number
+          $ref: '#/components/schemas/Pagination'
         records:
           type: array
           items:
             $ref: '#/components/schemas/SubmissionResult'
+
+    Pagination:
+      type: object
+      properties:
+        currentPage:
+          type: number
+        pageSize:
+          type: number
+        totalPages:
+          type: number
+        totalRecords:
+          type: number
 
     SubmissionResult:
       type: object

--- a/apps/submission/src/api-docs/schemas.yml
+++ b/apps/submission/src/api-docs/schemas.yml
@@ -117,6 +117,22 @@ components:
         updatedBy:
           type: string
           description: User name who last updated the submission
+    
+    CategorySummary:
+      type: object
+      properties:
+        alias:
+          type: string
+          description: Optional alias for the category. Not set if none is assigned.
+        id:
+          type: number
+          description: ID of the Submission
+        name:
+          type: string
+          description: Name of the Category
+        studyId:
+          type: string
+          description: Associated study with category
 
     ChangeHistorySummaryResult:
       type: object
@@ -318,21 +334,14 @@ components:
     ListAllCategories:
       type: array
       items:
-        type: object
-        properties:
-          id:
-            type: number
-            description: ID of the Submission
-          name:
-            type: string
-            description: Name of the Category
-          studyId:
-            type: string
-            description: Associated study with category
+        $ref: '#/components/schemas/CategorySummary'
 
     RegisterDictionaryResult:
       type: object
       properties:
+        alias:
+          type: string
+          description: Optional alias for the category. Not present if none was assigned.
         categoryId:
           type: number
           description: ID of the Category

--- a/apps/submission/src/api-docs/schemas.yml
+++ b/apps/submission/src/api-docs/schemas.yml
@@ -88,12 +88,15 @@ components:
     CategoryDetails:
       type: object
       properties:
-        id:
-          type: number
-          description: ID of the Category
-        name:
+        alias:
           type: string
-          description: Name of the Category
+          description: Optional alias for the category. Not set if none is assigned.
+        createdAt:
+          type: string
+          description: Date and time of creation
+        createdBy:
+          type: string
+          description: User name who created the submission
         dictionary:
           type: object
           description: Dictionary used to validate the submission
@@ -102,22 +105,22 @@ components:
               type: string
             version:
               type: string
-        studyId:
+        id:
+          type: number
+          description: ID of the Category
+        name:
           type: string
-          description: Associated study to this category
-        createdAt:
-          type: string
-          description: Date and time of creation
-        createdBy:
-          type: string
-          description: User name who created the submission
+          description: Name of the Category
         updatedAt:
           type: string
           description: Date and time of latest update
         updatedBy:
           type: string
           description: User name who last updated the submission
-    
+        studyId:
+          type: string
+          description: Associated study to this category
+
     CategorySummary:
       type: object
       properties:

--- a/apps/submission/src/api-docs/tags.yml
+++ b/apps/submission/src/api-docs/tags.yml
@@ -11,6 +11,8 @@ tags:
     description: Dictionary registration. Uses Dictionary Manager as source of truth for Dictionaries
   - name: Health
     description: Service status monitoring
+  - name: Migration
+    description: Operations related to Migrations management. Migrations are used to update and validate existing data against a new Dictionary version.
   - name: Submission
     description: Create, View, Edit and Commit a Submission. A Submission represents a collection of data that is staged for validation before finalization
   - name: Study

--- a/apps/submission/src/common/validation/category-validation.ts
+++ b/apps/submission/src/common/validation/category-validation.ts
@@ -23,7 +23,7 @@ import { z } from 'zod';
 
 import { RequestValidation } from '@/middleware/requestValidation.js';
 
-import { stringNotEmpty } from './common.js';
+import { categoryAliasSchema } from './common.js';
 
 interface CategoryIDParams extends ParamsDictionary {
 	categoryId: string;
@@ -31,12 +31,12 @@ interface CategoryIDParams extends ParamsDictionary {
 
 export const getCategoryByIDReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
 	pathParams: z.object({
-		categoryId: stringNotEmpty,
+		categoryId: categoryAliasSchema,
 	}),
 };
 
 export const removeStudyLinkFromCategoryReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
 	pathParams: z.object({
-		categoryId: stringNotEmpty,
+		categoryId: categoryAliasSchema,
 	}),
 };

--- a/apps/submission/src/common/validation/category-validation.ts
+++ b/apps/submission/src/common/validation/category-validation.ts
@@ -19,7 +19,7 @@
 
 import { ParamsDictionary } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
-import { z } from 'zod';
+import { z as zod } from 'zod';
 
 import { RequestValidation } from '@/middleware/requestValidation.js';
 
@@ -30,13 +30,13 @@ interface CategoryIDParams extends ParamsDictionary {
 }
 
 export const getCategoryByIDReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
-	pathParams: z.object({
+	pathParams: zod.object({
 		categoryId: categoryIdSchema,
 	}),
 };
 
 export const removeStudyLinkFromCategoryReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
-	pathParams: z.object({
+	pathParams: zod.object({
 		categoryId: categoryIdSchema,
 	}),
 };

--- a/apps/submission/src/common/validation/category-validation.ts
+++ b/apps/submission/src/common/validation/category-validation.ts
@@ -23,7 +23,7 @@ import { z } from 'zod';
 
 import { RequestValidation } from '@/middleware/requestValidation.js';
 
-import { categoryAliasSchema } from './common.js';
+import { categoryIdSchema } from './common.js';
 
 interface CategoryIDParams extends ParamsDictionary {
 	categoryId: string;
@@ -31,12 +31,12 @@ interface CategoryIDParams extends ParamsDictionary {
 
 export const getCategoryByIDReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
 	pathParams: z.object({
-		categoryId: categoryAliasSchema,
+		categoryId: categoryIdSchema,
 	}),
 };
 
 export const removeStudyLinkFromCategoryReqValidation: RequestValidation<object, ParsedQs, CategoryIDParams> = {
 	pathParams: z.object({
-		categoryId: categoryAliasSchema,
+		categoryId: categoryIdSchema,
 	}),
 };

--- a/apps/submission/src/common/validation/common.ts
+++ b/apps/submission/src/common/validation/common.ts
@@ -18,16 +18,16 @@
  */
 
 import { ParsedQs } from 'qs';
-import { z } from 'zod';
+import { z as zod } from 'zod';
 
-export const stringNotEmpty = z.string().trim().min(1);
-export const stringNotEmptyOptional = stringNotEmpty.or(z.literal('')).optional();
-export const orderByString = z.literal('asc').or(z.literal('desc'));
+export const stringNotEmpty = zod.string().trim().min(1);
+export const stringNotEmptyOptional = stringNotEmpty.or(zod.literal('')).optional();
+export const orderByString = zod.literal('asc').or(zod.literal('desc'));
 
 /**
- * Zod's `z.coerce` does not work in an "expected" way for booleans and will always return `true`
+ * Zod's `zod.coerce` does not work in an "expected" way for booleans and will always return `true`
  * for a boolean if the string it's parsing is not empty. This function will make the type
- * check work in an "expected" way if used in conjunction with the zod `z.preprocess` function.
+ * check work in an "expected" way if used in conjunction with the zod `zod.preprocess` function.
  *
  * @see https://github.com/colinhacks/zod/discussions/3329
  *
@@ -38,11 +38,11 @@ export const processCoercedBoolean = (potentialBoolean: unknown) => {
 	return String(potentialBoolean).toLowerCase().trim() === 'true' ? true : false;
 };
 
-export const positiveInteger = z.string().superRefine((value, ctx) => {
+export const positiveInteger = zod.string().superRefine((value, ctx) => {
 	const parsed = parseInt(value);
 	if (isNaN(parsed)) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_type,
+			code: zod.ZodIssueCode.invalid_type,
 			expected: 'number',
 			received: 'nan',
 		});
@@ -50,7 +50,7 @@ export const positiveInteger = z.string().superRefine((value, ctx) => {
 
 	if (parsed < 1) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.too_small,
+			code: zod.ZodIssueCode.too_small,
 			minimum: 1,
 			inclusive: true,
 			type: 'number',
@@ -58,11 +58,11 @@ export const positiveInteger = z.string().superRefine((value, ctx) => {
 	}
 });
 
-export const nonNegativeInteger = z.string().superRefine((value, ctx) => {
+export const nonNegativeInteger = zod.string().superRefine((value, ctx) => {
 	const parsed = parseInt(value);
 	if (isNaN(parsed)) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.invalid_type,
+			code: zod.ZodIssueCode.invalid_type,
 			expected: 'number',
 			received: 'nan',
 		});
@@ -70,7 +70,7 @@ export const nonNegativeInteger = z.string().superRefine((value, ctx) => {
 
 	if (parsed < 0) {
 		ctx.addIssue({
-			code: z.ZodIssueCode.too_small,
+			code: zod.ZodIssueCode.too_small,
 			minimum: 0,
 			inclusive: true,
 			type: 'number',
@@ -83,3 +83,28 @@ export interface PaginationParams extends ParsedQs {
 	page?: string;
 	pageSize?: string;
 }
+
+/**
+ * Checks if a string is safe as a category alias: a non-empty URL-safe slug (letters, numbers,
+ * hyphens, underscores, periods). A value that is *only* digits (e.g. `"5"`) is rejected, since
+ * category ids are whole numbers and an alias must never be able to collide with one, now or once
+ * the id sequence catches up to it. A value containing any other character, including a decimal
+ * point (e.g. `"2.5"`, `"v5"`, `"5-donor"`), can never be mistaken for an id and is allowed,
+ * including a data version label.
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isValidCategoryAlias(value: string): boolean {
+	if (/^\d+$/.test(value)) {
+		return false;
+	}
+	return /^[A-Za-z0-9_.-]+$/.test(value);
+}
+
+export const categoryAliasSchema = zod
+	.string()
+	.trim()
+	.refine(
+		(value) => value === '' || isValidCategoryAlias(value),
+		'alias must contain only letters, numbers, hyphens, and underscores',
+	);

--- a/apps/submission/src/common/validation/common.ts
+++ b/apps/submission/src/common/validation/common.ts
@@ -85,6 +85,22 @@ export interface PaginationParams extends ParsedQs {
 }
 
 /**
+ * Function that returns true if input is a valid number greater than zero.
+ * Otherwise it returns false
+ */
+export const isValidIdNumber = (value: unknown): boolean => {
+	return typeof value === 'number' && !isNaN(value) && value > 0 && value < Number.MAX_VALUE;
+};
+/**
+ * Schema for validating category ID or alias.
+ */
+export const categoryIdSchema = zod
+	.string()
+	.trim()
+	.min(1)
+	.refine((value) => isValidIdNumber(parseInt(value)) || isValidCategoryAlias(value), 'invalid category ID');
+
+/**
  * Checks if a string is safe as a category alias: a non-empty URL-safe slug (letters, numbers,
  * hyphens, underscores, periods). A value that is *only* digits (e.g. `"5"`) is rejected, since
  * category ids are whole numbers and an alias must never be able to collide with one, now or once

--- a/apps/submission/src/common/validation/common.ts
+++ b/apps/submission/src/common/validation/common.ts
@@ -120,7 +120,4 @@ export function isValidCategoryAlias(value: string): boolean {
 export const categoryAliasSchema = zod
 	.string()
 	.trim()
-	.refine(
-		(value) => value === '' || isValidCategoryAlias(value),
-		'alias must contain only letters, numbers, hyphens, and underscores',
-	);
+	.refine((value) => isValidCategoryAlias(value), 'alias must contain only letters, numbers, hyphens, and underscores');

--- a/apps/submission/src/common/validation/common.ts
+++ b/apps/submission/src/common/validation/common.ts
@@ -98,7 +98,10 @@ export const categoryIdSchema = zod
 	.string()
 	.trim()
 	.min(1)
-	.refine((value) => isValidIdNumber(parseInt(value)) || isValidCategoryAlias(value), 'invalid category ID');
+	.refine(
+		(value) => (/^\d+$/.test(value) && isValidIdNumber(Number(value))) || isValidCategoryAlias(value),
+		'Invalid category ID. Must be a positive integer or a valid alias.',
+	);
 
 /**
  * Checks if a string is safe as a category alias: a non-empty URL-safe slug (letters, numbers,

--- a/apps/submission/src/common/validation/dictionary-validation.ts
+++ b/apps/submission/src/common/validation/dictionary-validation.ts
@@ -26,6 +26,7 @@ import { RequestValidation } from '@/middleware/requestValidation.js';
 import { stringNotEmpty, stringNotEmptyOptional } from './common.js';
 
 type RegisterDictionaryBody = {
+	alias?: string;
 	studyId: string;
 	categoryName: string;
 	dictionaryName: string;
@@ -35,6 +36,7 @@ type RegisterDictionaryBody = {
 
 export const registerDictionaryValidation: RequestValidation<RegisterDictionaryBody, ParsedQs, ParamsDictionary> = {
 	body: z.object({
+		alias: stringNotEmptyOptional,
 		studyId: stringNotEmpty,
 		categoryName: stringNotEmpty,
 		dictionaryName: stringNotEmpty,

--- a/apps/submission/src/common/validation/dictionary-validation.ts
+++ b/apps/submission/src/common/validation/dictionary-validation.ts
@@ -23,7 +23,7 @@ import { z } from 'zod';
 
 import { RequestValidation } from '@/middleware/requestValidation.js';
 
-import { stringNotEmpty, stringNotEmptyOptional } from './common.js';
+import { stringNotEmpty, stringNotEmptyOptional, categoryAliasSchema } from './common.js';
 
 type RegisterDictionaryBody = {
 	alias?: string;
@@ -36,7 +36,7 @@ type RegisterDictionaryBody = {
 
 export const registerDictionaryValidation: RequestValidation<RegisterDictionaryBody, ParsedQs, ParamsDictionary> = {
 	body: z.object({
-		alias: stringNotEmptyOptional,
+		alias: categoryAliasSchema,
 		studyId: stringNotEmpty,
 		categoryName: stringNotEmpty,
 		dictionaryName: stringNotEmpty,

--- a/apps/submission/src/common/validation/dictionary-validation.ts
+++ b/apps/submission/src/common/validation/dictionary-validation.ts
@@ -36,7 +36,7 @@ type RegisterDictionaryBody = {
 
 export const registerDictionaryValidation: RequestValidation<RegisterDictionaryBody, ParsedQs, ParamsDictionary> = {
 	body: zod.object({
-		alias: categoryAliasSchema,
+		alias: categoryAliasSchema.optional(),
 		studyId: stringNotEmpty,
 		categoryName: stringNotEmpty,
 		dictionaryName: stringNotEmpty,

--- a/apps/submission/src/common/validation/dictionary-validation.ts
+++ b/apps/submission/src/common/validation/dictionary-validation.ts
@@ -19,11 +19,11 @@
 
 import { ParamsDictionary } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
-import { z } from 'zod';
+import { z as zod } from 'zod';
 
 import { RequestValidation } from '@/middleware/requestValidation.js';
 
-import { stringNotEmpty, stringNotEmptyOptional, categoryAliasSchema } from './common.js';
+import { categoryAliasSchema, stringNotEmpty, stringNotEmptyOptional } from './common.js';
 
 type RegisterDictionaryBody = {
 	alias?: string;
@@ -35,7 +35,7 @@ type RegisterDictionaryBody = {
 };
 
 export const registerDictionaryValidation: RequestValidation<RegisterDictionaryBody, ParsedQs, ParamsDictionary> = {
-	body: z.object({
+	body: zod.object({
 		alias: categoryAliasSchema,
 		studyId: stringNotEmpty,
 		categoryName: stringNotEmpty,

--- a/apps/submission/src/common/validation/submit-validation.ts
+++ b/apps/submission/src/common/validation/submit-validation.ts
@@ -24,7 +24,7 @@ import { z as zod } from 'zod';
 import { lyricProvider } from '@/core/provider.js';
 import { type RequestValidation } from '@/middleware/requestValidation.js';
 
-import { categoryAliasSchema, nonNegativeInteger, positiveInteger } from './common.js';
+import { categoryIdSchema, nonNegativeInteger, positiveInteger } from './common.js';
 
 interface SubmitRequestPathParams extends ParamsDictionary {
 	categoryId: string;
@@ -41,7 +41,7 @@ export const submitRequestSchema: RequestValidation<
 		organization: zod.string(),
 	}),
 	pathParams: zod.object({
-		categoryId: categoryAliasSchema,
+		categoryId: categoryIdSchema,
 	}),
 };
 
@@ -60,7 +60,7 @@ export const editDataRequestSchema: RequestValidation<
 		organization: zod.string(),
 	}),
 	pathParams: zod.object({
-		categoryId: categoryAliasSchema,
+		categoryId: categoryIdSchema,
 	}),
 };
 

--- a/apps/submission/src/common/validation/submit-validation.ts
+++ b/apps/submission/src/common/validation/submit-validation.ts
@@ -19,12 +19,12 @@
 
 import type { ParamsDictionary } from 'express-serve-static-core';
 import type { ParsedQs } from 'qs';
-import { z } from 'zod';
+import { z as zod } from 'zod';
 
 import { lyricProvider } from '@/core/provider.js';
 import { type RequestValidation } from '@/middleware/requestValidation.js';
 
-import { nonNegativeInteger, positiveInteger } from './common.js';
+import { categoryAliasSchema, nonNegativeInteger, positiveInteger } from './common.js';
 
 interface SubmitRequestPathParams extends ParamsDictionary {
 	categoryId: string;
@@ -37,11 +37,11 @@ export const submitRequestSchema: RequestValidation<
 	ParsedQs,
 	SubmitRequestPathParams
 > = {
-	body: z.object({
-		organization: z.string(),
+	body: zod.object({
+		organization: zod.string(),
 	}),
-	pathParams: z.object({
-		categoryId: z.string(),
+	pathParams: zod.object({
+		categoryId: categoryAliasSchema,
 	}),
 };
 
@@ -56,11 +56,11 @@ export const editDataRequestSchema: RequestValidation<
 	ParsedQs,
 	EditRequestPathParams
 > = {
-	body: z.object({
-		organization: z.string(),
+	body: zod.object({
+		organization: zod.string(),
 	}),
-	pathParams: z.object({
-		categoryId: z.string(),
+	pathParams: zod.object({
+		categoryId: categoryAliasSchema,
 	}),
 };
 
@@ -74,7 +74,7 @@ export interface submissionDeleteEntityNameQueryParams extends ParsedQs {
 	index?: string;
 }
 
-const submissionActionTypeSchema = z
+const submissionActionTypeSchema = zod
 	.string()
 	.trim()
 	.min(1)
@@ -85,11 +85,11 @@ export const deleteEntityRequestSchema: RequestValidation<
 	submissionDeleteEntityNameQueryParams,
 	submissionDeleteEntityNameParams
 > = {
-	query: z.object({
-		entityName: z.string().trim().min(1),
+	query: zod.object({
+		entityName: zod.string().trim().min(1),
 		index: nonNegativeInteger.optional(),
 	}),
-	pathParams: z.object({
+	pathParams: zod.object({
 		actionType: submissionActionTypeSchema,
 		submissionId: positiveInteger,
 	}),

--- a/apps/submission/src/controllers/categoryController.ts
+++ b/apps/submission/src/controllers/categoryController.ts
@@ -29,26 +29,28 @@ import { studyService } from '@/service/studyService.js';
 
 const unlinkStudiesFromCategory = validateRequest(removeStudyLinkFromCategoryReqValidation, async (req, res, next) => {
 	try {
-		const categoryId = Number(req.params.categoryId);
+		const categoryIdOrAlias = req.params.categoryId;
 		const database = getDbInstance();
 
 		const studySvc = await studyService(database);
 
-		const foundCategory = await lyricProvider.services.category.getDetails(categoryId);
+		const foundCategory = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
 		if (!foundCategory) {
-			throw new lyricProvider.utils.errors.NotFound(`No Category with ID - ${categoryId} found.`);
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
 		}
 
-		const submittedDataCount = await lyricProvider.repositories.submittedData.getTotalRecordsByCategoryId(categoryId);
+		const submittedDataCount = await lyricProvider.repositories.submittedData.getTotalRecordsByCategoryId(
+			foundCategory.id,
+		);
 		if (submittedDataCount > 0) {
 			throw new lyricProvider.utils.errors.BadRequest(
-				`Cannot remove study link from category ${categoryId} because it has ${submittedDataCount} records submitted`,
+				`Cannot remove study link from category ${categoryIdOrAlias} because it has ${submittedDataCount} records submitted`,
 			);
 		}
 
-		const linkedStudies = await studySvc.getStudiesByCategoryIds([categoryId]);
+		const linkedStudies = await studySvc.getStudiesByCategoryIds([foundCategory.id]);
 		if (linkedStudies.length > 0) {
-			await studySvc.unlinkStudiesFromCategory(categoryId);
+			await studySvc.unlinkStudiesFromCategory(foundCategory.id);
 		}
 
 		res.status(204).send();
@@ -60,19 +62,19 @@ const unlinkStudiesFromCategory = validateRequest(removeStudyLinkFromCategoryReq
 });
 
 const getCategoryById = validateRequest(getCategoryByIDReqValidation, async (req, res, next) => {
-	const categoryId = Number(req.params.categoryId);
+	const categoryIdOrAlias = req.params.categoryId;
 	const database = getDbInstance();
 	const categoryService = lyricProvider.services.category;
 	const studySvc = await studyService(database);
 
 	try {
-		const foundCategory = await categoryService.getDetails(categoryId);
+		const foundCategory = await categoryService.getDetails(categoryIdOrAlias);
 
 		if (!foundCategory) {
-			throw new lyricProvider.utils.errors.NotFound(`No Category with ID - ${categoryId} found.`);
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
 		}
 
-		const linkedStudies = await studySvc.getStudiesByCategoryIds([categoryId]);
+		const linkedStudies = await studySvc.getStudiesByCategoryIds([foundCategory.id]);
 
 		const study = linkedStudies[0]?.study_id;
 

--- a/apps/submission/src/controllers/dataController.ts
+++ b/apps/submission/src/controllers/dataController.ts
@@ -86,18 +86,24 @@ const getCategoryById = validateRequest(
 			const studySvc = studyService(db);
 
 			// request params
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const entityName = asArray(req.query.entityName || []);
 			const page = parseInt(String(req.query.page)) || defaultPage;
 			const pageSize = parseInt(String(req.query.pageSize)) || defaultPageSize;
 			const view = convertToViewType(req.query.view) || defaultView;
 			const user = req.user;
 
-			const studiesByCategory = await studySvc.getStudiesByCategoryId(categoryId);
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
+
+			const studiesByCategory = await studySvc.getStudiesByCategoryId(category.id);
 			const studyByCategory = studiesByCategory[0];
 
 			if (!studyByCategory) {
-				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${categoryId}".`);
+				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${category.id}".`);
 			}
 
 			if (!hasAllowedAccess(studyByCategory.study_id, 'READ', user)) {
@@ -108,7 +114,7 @@ const getCategoryById = validateRequest(
 
 			// Send submission data, organized by entity.
 			const submitResult = await lyricProvider.services.submittedData.getSubmittedDataByCategory(
-				categoryId,
+				category.id,
 				{ page, pageSize },
 				{ entityName, view, organizations: [studyByCategory.study_id] },
 			);
@@ -141,16 +147,20 @@ const getCategoryBySystemId = validateRequest(
 			const studySvc = studyService(db);
 
 			// request params
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const systemId = req.params.systemId;
 			const view = convertToViewType(String(req.query.view)) || defaultView;
 			const user = req.user;
 
-			const studiesByCategory = await studySvc.getStudiesByCategoryId(categoryId);
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
+			const studiesByCategory = await studySvc.getStudiesByCategoryId(category.id);
 			const studyByCategory = studiesByCategory[0];
 
 			if (!studyByCategory) {
-				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${categoryId}".`);
+				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${category.id}".`);
 			}
 
 			if (!hasAllowedAccess(studyByCategory.study_id, 'READ', user)) {
@@ -160,9 +170,13 @@ const getCategoryBySystemId = validateRequest(
 			}
 
 			// Send submission data, organized by entity.
-			const submitResult = await lyricProvider.services.submittedData.getSubmittedDataBySystemId(categoryId, systemId, {
-				view,
-			});
+			const submitResult = await lyricProvider.services.submittedData.getSubmittedDataBySystemId(
+				category.id,
+				systemId,
+				{
+					view,
+				},
+			);
 
 			if (!submitResult.result) {
 				res.status(404).send(submitResult.metadata.errorMessage);
@@ -187,7 +201,7 @@ const getCategoryByOrganization = validateRequest(
 			const studySvc = studyService(db);
 
 			// request parameters
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const organization = req.params.organization;
 			const entityName = asArray(req.query.entityName || []);
 			const page = parseInt(String(req.query.page)) || defaultPage;
@@ -195,16 +209,21 @@ const getCategoryByOrganization = validateRequest(
 			const view = convertToViewType(String(req.query.view)) || defaultView;
 			const user = req.user;
 
-			const studiesByCategory = await studySvc.getStudiesByCategoryId(categoryId);
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
+
+			const studiesByCategory = await studySvc.getStudiesByCategoryId(category.id);
 			const studyByCategory = studiesByCategory[0];
 
 			if (!studyByCategory) {
-				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${categoryId}".`);
+				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${category.id}".`);
 			}
 
 			if (studyByCategory.study_id !== organization) {
 				throw new lyricProvider.utils.errors.BadRequest(
-					`The provided organization '${organization}' is not associated with categoryId '${categoryId}'. Please verify that you are using the correct categoryId for the organization `,
+					`The provided organization '${organization}' is not associated with categoryId '${category.id}'. Please verify that you are using the correct categoryId for the organization `,
 				);
 			}
 
@@ -216,7 +235,7 @@ const getCategoryByOrganization = validateRequest(
 
 			// Send submission data, organized by entity.
 			const submitResult = await lyricProvider.services.submittedData.getSubmittedDataByOrganization(
-				categoryId,
+				category.id,
 				organization,
 				{
 					page,
@@ -257,7 +276,7 @@ const getSubmittedDataByQuery = validateRequest(
 			const studySvc = studyService(db);
 
 			// request parameters
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const organization = req.params.organization;
 			const sqon = lyricProvider.utils.convertSqonToQuery.parseSQON(req.body);
 			const entityName = asArray(req.query.entityName || []);
@@ -266,16 +285,21 @@ const getSubmittedDataByQuery = validateRequest(
 			const view = convertToViewType(String(req.query.view)) || defaultView;
 			const user = req.user;
 
-			const studiesByCategory = await studySvc.getStudiesByCategoryId(categoryId);
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
+
+			const studiesByCategory = await studySvc.getStudiesByCategoryId(category.id);
 			const studyByCategory = studiesByCategory[0];
 
 			if (!studyByCategory) {
-				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${categoryId}".`);
+				throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${category.id}".`);
 			}
 
 			if (studyByCategory.study_id !== organization) {
 				throw new lyricProvider.utils.errors.BadRequest(
-					`The provided organization '${organization}' is not associated with categoryId '${categoryId}'. Please verify that you are using the correct categoryId for the organization `,
+					`The provided organization '${organization}' is not associated with categoryId '${category.id}'. Please verify that you are using the correct categoryId for the organization `,
 				);
 			}
 
@@ -287,7 +311,7 @@ const getSubmittedDataByQuery = validateRequest(
 
 			// Send submission data, organized by entity.
 			const submitResult = await lyricProvider.services.submittedData.getSubmittedDataByOrganization(
-				categoryId,
+				category.id,
 				organization,
 				{
 					page,
@@ -320,14 +344,19 @@ const getSubmittedDataStream = validateRequest(
 	lyricProvider.utils.schema.dataGetByCategoryRequestSchema,
 	async (req, res, next) => {
 		try {
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const entityName = asArray(req.query.entityName || []);
 			const view = convertToViewType(String(req.query.view)) || defaultView;
+
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
 
 			res.setHeader('Transfer-Encoding', 'chunked');
 			res.setHeader('Content-Type', 'application/x-ndjson');
 
-			for await (const data of lyricProvider.services.submittedData.getSubmittedDataByCategoryStream(categoryId, {
+			for await (const data of lyricProvider.services.submittedData.getSubmittedDataByCategoryStream(category.id, {
 				view,
 				entityName,
 			})) {

--- a/apps/submission/src/controllers/dictionaryController.ts
+++ b/apps/submission/src/controllers/dictionaryController.ts
@@ -25,7 +25,7 @@ import { studyService } from '@/service/studyService.js';
 
 const registerDictionary = validateRequest(registerDictionaryValidation, async (req, res, next) => {
 	try {
-		const { studyId, categoryName, dictionaryName, dictionaryVersion, defaultCentricEntity } = req.body;
+		const { alias, studyId, categoryName, dictionaryName, dictionaryVersion, defaultCentricEntity } = req.body;
 		const user = req.user;
 
 		const db = getDbInstance();
@@ -46,6 +46,7 @@ const registerDictionary = validateRequest(registerDictionaryValidation, async (
 		}
 
 		const { dictionary, category } = await lyricProvider.services.dictionary.register({
+			alias,
 			categoryName,
 			dictionaryName,
 			dictionaryVersion,

--- a/apps/submission/src/controllers/submissionController.ts
+++ b/apps/submission/src/controllers/submissionController.ts
@@ -53,7 +53,7 @@ const DEFAULT_PAGE_SIZE = 20;
 
 const editData = validateRequest(editDataRequestSchema, async (req, res, next) => {
 	try {
-		const categoryId = Number(req.params.categoryId);
+		const categoryIdOrAlias = req.params.categoryId;
 		const files = Array.isArray(req.files) ? req.files : [];
 		const organization = req.body.organization;
 		const db = getDbInstance();
@@ -65,10 +65,15 @@ const editData = validateRequest(editDataRequestSchema, async (req, res, next) =
 			throw new lyricProvider.utils.errors.Forbidden('You do not have permission to access this resource');
 		}
 
-		const results = await studySvc.getStudiesByCategoryId(categoryId);
+		const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+		if (!category) {
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+		}
+
+		const results = await studySvc.getStudiesByCategoryId(category.id);
 
 		if (!results?.length) {
-			throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${categoryId}".`);
+			throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId "${category.id}".`);
 		}
 
 		const study = results[0];
@@ -88,10 +93,10 @@ const editData = validateRequest(editDataRequestSchema, async (req, res, next) =
 		}
 
 		// get the current dictionary
-		const currentDictionary = await lyricProvider.services.dictionary.getActiveDictionaryByCategory(categoryId);
+		const currentDictionary = await lyricProvider.services.dictionary.getActiveDictionaryByCategory(category.id);
 
 		if (!currentDictionary) {
-			throw new lyricProvider.utils.errors.BadRequest(`Dictionary in category '${categoryId}' not found`);
+			throw new lyricProvider.utils.errors.BadRequest(`Dictionary in category '${category.id}' not found`);
 		}
 
 		const fileErrors: BatchError[] = [];
@@ -123,7 +128,7 @@ const editData = validateRequest(editDataRequestSchema, async (req, res, next) =
 				const uploadResult = await lyricProvider.services.submittedData.editSubmittedData({
 					records: extractedData,
 					entityName,
-					categoryId,
+					categoryId: category.id,
 					organization,
 					username: username ?? '',
 				});
@@ -167,7 +172,7 @@ const CREATE_SUBMISSION_STATUS = {
 
 const submit = validateRequest(submitRequestSchema, async (req, res, next) => {
 	try {
-		const categoryId = Number(req.params.categoryId);
+		const categoryIdOrAlias = req.params.categoryId;
 		const files = Array.isArray(req.files) ? req.files : [];
 		const organization = req.body.organization;
 		const user = req.user;
@@ -184,24 +189,29 @@ const submit = validateRequest(submitRequestSchema, async (req, res, next) => {
 			throw new lyricProvider.utils.errors.Forbidden('You do not have permission to access this resource');
 		}
 
-		const results = await studySvc.getStudiesByCategoryId(categoryId);
+		const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+		if (!category) {
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+		}
+
+		const results = await studySvc.getStudiesByCategoryId(category.id);
 
 		if (!results?.length) {
-			throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId - ${categoryId}.`);
+			throw new lyricProvider.utils.errors.NotFound(`No Study found with categoryId - ${category.id}.`);
 		}
 
 		const foundStudy = results[0];
 
 		if (foundStudy?.study_id !== organization) {
 			throw new lyricProvider.utils.errors.BadRequest(
-				`The provided organization '${organization}' is not associated with categoryId '${categoryId}'. Please verify that you are submitting to the correct categoryId for the organization`,
+				`The provided organization '${organization}' is not associated with categoryId '${category.id}'. Please verify that you are submitting to the correct categoryId for the organization`,
 			);
 		}
 
 		const username = user?.username;
 
 		logger.info(
-			`Upload Submission Request: categoryId '${categoryId}'` +
+			`Upload Submission Request: categoryId '${category.id}'` +
 				` organization '${organization}'` +
 				` files: '${files?.map((f) => f.originalname)}'`,
 		);
@@ -213,10 +223,10 @@ const submit = validateRequest(submitRequestSchema, async (req, res, next) => {
 		}
 
 		// get the current dictionary
-		const currentDictionary = await lyricProvider.services.dictionary.getActiveDictionaryByCategory(categoryId);
+		const currentDictionary = await lyricProvider.services.dictionary.getActiveDictionaryByCategory(category.id);
 
 		if (!currentDictionary) {
-			throw new lyricProvider.utils.errors.BadRequest(`Dictionary in category '${categoryId}' not found`);
+			throw new lyricProvider.utils.errors.BadRequest(`Dictionary in category '${category.id}' not found`);
 		}
 
 		const fileErrors: BatchError[] = [];
@@ -255,7 +265,7 @@ const submit = validateRequest(submitRequestSchema, async (req, res, next) => {
 		// Send submission data, organized by entity.
 		const submitResult = await lyricProvider.services.submission.submit({
 			data: entityData,
-			categoryId,
+			categoryId: category.id,
 			organization,
 			username: username ?? '',
 		});
@@ -291,7 +301,7 @@ const submit = validateRequest(submitRequestSchema, async (req, res, next) => {
 
 const commit = validateRequest(lyricProvider.utils.schema.submissionCommitRequestSchema, async (req, res, next) => {
 	try {
-		const categoryId = Number(req.params.categoryId);
+		const categoryIdOrAlias = req.params.categoryId;
 		const submissionId = Number(req.params.submissionId);
 		const user = req.user;
 
@@ -313,14 +323,19 @@ const commit = validateRequest(lyricProvider.utils.schema.submissionCommitReques
 			throw new lyricProvider.utils.errors.Forbidden('You do not have permission to access this resource.');
 		}
 
-		if (categoryId !== submission.dictionaryCategory.id) {
+		const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+		if (!category) {
+			throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+		}
+
+		if (category.id !== submission.dictionaryCategory.id) {
 			throw new lyricProvider.utils.errors.BadRequest(
 				'Mismatch between category ID and submission ID. No submission with the given ID exists for the specified category.',
 			);
 		}
 
 		const commitSubmission = await lyricProvider.services.submission.commitSubmission(
-			categoryId,
+			category.id,
 			submissionId,
 			user?.username,
 		);
@@ -415,15 +430,20 @@ const getSubmissionsByCategory = validateRequest(
 	lyricProvider.utils.schema.submissionsByCategoryRequestSchema,
 	async (req, res, next) => {
 		try {
-			const categoryId = Number(req.params.categoryId);
+			const categoryIdOrAlias = req.params.categoryId;
 			const onlyActive = req.query.onlyActive?.toLowerCase() === 'true';
 			const organization = req.query.organization;
 			const page = parseInt(String(req.query.page)) || DEFAULT_PAGE;
 			const pageSize = parseInt(String(req.query.pageSize)) || DEFAULT_PAGE_SIZE;
 			const user = req.user;
 
+			const category = await lyricProvider.services.category.getDetails(categoryIdOrAlias);
+			if (!category) {
+				throw new lyricProvider.utils.errors.NotFound(`No Category with ID or Alias - ${categoryIdOrAlias} found.`);
+			}
+
 			const submissionsResult = await lyricProvider.services.submission.getSubmissionsByCategory(
-				categoryId,
+				category.id,
 				{ page, pageSize },
 				{ onlyActive, username: user?.username, organization },
 			);

--- a/apps/submission/src/middleware/idManager.ts
+++ b/apps/submission/src/middleware/idManager.ts
@@ -113,7 +113,7 @@ const processInsertedRecords = async (insertedRecords: SubmittedDataResponse[], 
 	return recordStats;
 };
 
-export const onFinishCommitCallback = (resultOnCommit: ResultOnCommit) => {
+export const onFinishCommitCallback = async (resultOnCommit: ResultOnCommit) => {
 	const { data } = resultOnCommit;
 	const db = getDbInstance();
 
@@ -124,5 +124,5 @@ export const onFinishCommitCallback = (resultOnCommit: ResultOnCommit) => {
 		return;
 	}
 
-	Promise.resolve(processInsertedRecords(data.inserts, db));
+	await processInsertedRecords(data.inserts, db);
 };

--- a/apps/submission/src/middleware/idManager.ts
+++ b/apps/submission/src/middleware/idManager.ts
@@ -124,5 +124,10 @@ export const onFinishCommitCallback = async (resultOnCommit: ResultOnCommit) => 
 		return;
 	}
 
-	await processInsertedRecords(data.inserts, db);
+	try {
+		await processInsertedRecords(data.inserts, db);
+	} catch (error) {
+		logger.error(`[Middleware/IIM]: Error processing inserted records: ${error}`);
+		// We don't want to throw an error here. We just log the error and continue.
+	}
 };

--- a/apps/submission/src/routes/categoryRouter.ts
+++ b/apps/submission/src/routes/categoryRouter.ts
@@ -22,6 +22,8 @@ import express, { json, Router, urlencoded } from 'express';
 import categoryController from '@/controllers/categoryController.js';
 import { authMiddleware } from '@/middleware/auth.js';
 
+import { lyricProvider } from '../core/provider.js';
+
 export const categoryRouter: Router = (() => {
 	const router = express.Router();
 	router.use(json());
@@ -31,6 +33,16 @@ export const categoryRouter: Router = (() => {
 		'/:categoryId/study',
 		authMiddleware({ requireAdmin: true }),
 		categoryController.unlinkStudiesFromCategory,
+	);
+	router.put(
+		'/:categoryId/alias',
+		authMiddleware({ requireAdmin: true }),
+		lyricProvider.controllers.category.assignAlias,
+	);
+	router.delete(
+		'/:categoryId/alias',
+		authMiddleware({ requireAdmin: true }),
+		lyricProvider.controllers.category.unassignAlias,
 	);
 
 	// Public endpoints – do not require authentication

--- a/apps/submission/src/server.ts
+++ b/apps/submission/src/server.ts
@@ -99,6 +99,7 @@ app.use('/auth-session', authSessionRouter);
 
 // Lyric Routes
 app.use('/audit', lyricProvider.routers.audit);
+app.use('/migration', lyricProvider.routers.migration);
 
 /**
  * Lyric Custom Routes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/validation
       '@overture-stack/lyric':
-        specifier: ^0.17.0
-        version: 0.17.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)
+        specifier: ^0.19.0
+        version: 0.19.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)
       axios:
         specifier: ^1.10.0
         version: 1.12.2
@@ -1110,11 +1110,11 @@ packages:
   '@overture-stack/lectern-validation@2.0.0-beta.6':
     resolution: {integrity: sha512-DVIi9SSX/pqYm/Tj1a3zREMCg3SaFrkZ96slmhIco2PmY19ibTxyOwFSvJxYTqLrBhjyBeHyy3ihUJw55WslUw==}
 
-  '@overture-stack/lyric-data-model@0.17.0':
-    resolution: {integrity: sha512-u5scjkInShbqV+Rh7xvC7fgbAdyWJ/DRsDLg3msBN4KoFSr5ZquvIpkihrnBtIiyq1rjPmB0ex1gB+PiS7U8SQ==}
+  '@overture-stack/lyric-data-model@0.19.0':
+    resolution: {integrity: sha512-pUeydcVBOcOhE9Hkj+OkyHokuJlJAXgKEoSgSZHuO0I5FbRrEIqA5UBpD8jPY7+VX9ed5WV3d/HMZHYRsMrN7A==}
 
-  '@overture-stack/lyric@0.17.0':
-    resolution: {integrity: sha512-5AaiKtfB/C2dmgbV/op9/DRhm5hkewe9AkGcYVoUq1SoBJ+Ropb6wTXoyciIpXK1pu13c9qIpAQifLALBXbfBg==}
+  '@overture-stack/lyric@0.19.0':
+    resolution: {integrity: sha512-/FhZASHx0gk6AOkj6KIfydONW+bnK90e0AgPLvUGXZUs/qjYBFoO5rZrMgknSoa0+dGNYork9ElZaadGo5RgvA==}
     engines: {node: '>=20.0.0'}
 
   '@overture-stack/sqon-builder@1.1.0':
@@ -4660,7 +4660,7 @@ snapshots:
       lodash: 4.17.21
       zod: 3.25.76
 
-  '@overture-stack/lyric-data-model@0.17.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)':
+  '@overture-stack/lyric-data-model@0.19.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@overture-stack/lectern-client': 2.0.0-beta.6
       copyfiles: 2.4.1
@@ -4692,10 +4692,10 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@overture-stack/lyric@0.17.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)':
+  '@overture-stack/lyric@0.19.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@overture-stack/lectern-client': 2.0.0-beta.6
-      '@overture-stack/lyric-data-model': 0.17.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)
+      '@overture-stack/lyric-data-model': 0.19.0(@types/pg@8.15.5)(@types/react@19.2.2)(react@19.2.0)
       '@overture-stack/sqon-builder': 1.1.0
       bytes: 3.1.2
       csv-parse: 6.2.1


### PR DESCRIPTION
# Summary
This PR upgrades Lyric to latest version `0.19.0` including new features and bug fixes.

### Details
- **Category aliases are now supported.** Aliases are string identifiers (letters, numbers, hyphens, and underscores) that can be used interchangeably with category IDs across all relevant endpoints.
- **Kafka integration has been added.** Committed records are now published to the configured Kafka topic.
- **Dictionary data migration has been implemented.** The Register Category Dictionary endpoint now returns a `migrationId`, which is used to validate all data in the category against the new dictionary.